### PR TITLE
feat(lvt): migrate templates to method dispatch pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -812,22 +812,30 @@ type State struct {
     // ...
 }
 
-func (s *State) Change(ctx *livetemplate.ActionContext) error {
-    switch ctx.Action {
-    case "add":
-        // Create user
-    case "update":
-        // Update user
-    case "delete":
-        // Delete user
-    case "search":
-        // Search users
-    // ...
-    }
+// Action methods - automatically dispatched based on action name
+func (s *State) Add(ctx *livetemplate.ActionContext) error {
+    // Create user
+    return nil
+}
+
+func (s *State) Update(ctx *livetemplate.ActionContext) error {
+    // Update user
+    return nil
+}
+
+func (s *State) Delete(ctx *livetemplate.ActionContext) error {
+    // Delete user
+    return nil
+}
+
+func (s *State) Search(ctx *livetemplate.ActionContext) error {
+    // Search users
+    return nil
 }
 
 func (s *State) Init() error {
     // Load initial data
+    return nil
 }
 
 func Handler(queries *models.Queries) http.Handler {

--- a/e2e/livetemplate_core_test.go
+++ b/e2e/livetemplate_core_test.go
@@ -1129,15 +1129,12 @@ func TestTemplate_E2E_CompleteRenderingSequence(t *testing.T) {
 	})
 }
 
-// LoadingTestState implements the Store interface for loading indicator E2E coverage.
+// LoadingTestState implements state for loading indicator E2E coverage.
 type LoadingTestState struct {
 	Message string
 }
 
-// Change satisfies the Store interface; loading tests do not mutate state.
-func (s *LoadingTestState) Change(ctx *livetemplate.ActionContext) error {
-	return nil
-}
+// No action methods needed - loading tests do not mutate state.
 
 // TestLoadingIndicator verifies the loading indicator appears serverside and disappears once the client boots.
 func TestLoadingIndicator(t *testing.T) {
@@ -1377,12 +1374,9 @@ type FocusTestState struct {
 	Counter int
 }
 
-// Change applies focus test actions.
-func (s *FocusTestState) Change(ctx *livetemplate.ActionContext) error {
-	switch ctx.Action {
-	case "increment":
-		s.Counter++
-	}
+// Increment handles the "increment" action.
+func (s *FocusTestState) Increment(_ *livetemplate.ActionContext) error {
+	s.Counter++
 	return nil
 }
 

--- a/internal/generator/templates/app/home.go.tmpl
+++ b/internal/generator/templates/app/home.go.tmpl
@@ -23,10 +23,7 @@ type Resource struct {
 	Type string `json:"type"`
 }
 
-func (s *HomeState) Change(ctx *livetemplate.ActionContext) error {
-	// No actions for home page yet
-	return nil
-}
+// No action methods needed for home page (static)
 
 // Handler creates an http.Handler for the home page
 func Handler() http.Handler {

--- a/internal/generator/templates/resource/handler.go.tmpl
+++ b/internal/generator/templates/resource/handler.go.tmpl
@@ -82,215 +82,286 @@ type [[.ResourceName]]State struct {
 	CSSFramework   string              `json:"-"`               // CSS framework for templates
 }
 
-func (s *[[.ResourceName]]State) Change(ctx *livetemplate.ActionContext) error {
+// Add handles the "add" action to create a new resource
+func (s *[[.ResourceName]]State) Add(ctx *livetemplate.ActionContext) error {
 	dbCtx := context.Background()
 
-	switch ctx.Action {
-	case "add":
-		var input AddInput
-		if err := ctx.BindAndValidate(&input, validate); err != nil {
-			return err
-		}
+	var input AddInput
+	if err := ctx.BindAndValidate(&input, validate); err != nil {
+		return err
+	}
 
-		log.Printf("[lvt debug] add input: %+v", input)
+	log.Printf("[lvt debug] add input: %+v", input)
 
-		now := time.Now()
-		id := fmt.Sprintf("[[.ResourceNameLower]]-%d", now.UnixNano())
+	now := time.Now()
+	id := fmt.Sprintf("[[.ResourceNameLower]]-%d", now.UnixNano())
 
-		_, err := s.Queries.Create[[.ResourceNameSingular]](dbCtx, models.Create[[.ResourceNameSingular]]Params{
-			ID:        id,
+	_, err := s.Queries.Create[[.ResourceNameSingular]](dbCtx, models.Create[[.ResourceNameSingular]]Params{
+		ID:        id,
 [[- range .Fields]]
-			[[.Name | camelCase]]: input.[[.Name | camelCase]],
+		[[.Name | camelCase]]: input.[[.Name | camelCase]],
 [[- end]]
-			CreatedAt: now,
-		})
-		if err != nil {
-			return fmt.Errorf("failed to create [[.ResourceNameLower]]: %w", err)
-		}
+		CreatedAt: now,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create [[.ResourceNameLower]]: %w", err)
+	}
 
-		if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
-			return err
-		}
+	if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
+		return err
+	}
 
-	case "edit":
-		var input DeleteInput
-		if err := ctx.BindAndValidate(&input, validate); err != nil {
-			return err
-		}
+	s.LastUpdated = formatTime()
+	return nil
+}
 
-		// Find the item to edit
-		[[.ResourceNameLower]]s, err := s.Queries.GetAll[[.ResourceNamePlural]](dbCtx)
-		if err != nil {
-			return fmt.Errorf("failed to load [[.ResourceNameLower]]s: %w", err)
-		}
+// Edit handles the "edit" action to start editing a resource
+func (s *[[.ResourceName]]State) Edit(ctx *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
 
+	var input DeleteInput
+	if err := ctx.BindAndValidate(&input, validate); err != nil {
+		return err
+	}
+
+	// Find the item to edit
+	[[.ResourceNameLower]]s, err := s.Queries.GetAll[[.ResourceNamePlural]](dbCtx)
+	if err != nil {
+		return fmt.Errorf("failed to load [[.ResourceNameLower]]s: %w", err)
+	}
+
+	for _, item := range [[.ResourceNameLower]]s {
+		if item.ID == input.ID {
+			s.EditingID = input.ID
+			itemCopy := item
+			s.Editing[[.ResourceName]] = &itemCopy
+			break
+		}
+	}
+
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// Update handles the "update" action to save changes to a resource
+func (s *[[.ResourceName]]State) Update(ctx *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
+
+	var input UpdateInput
+	if err := ctx.BindAndValidate(&input, validate); err != nil {
+		return err
+	}
+
+	err := s.Queries.Update[[.ResourceNameSingular]](dbCtx, models.Update[[.ResourceNameSingular]]Params{
+		ID: input.ID,
+[[- range .Fields]]
+		[[.Name | camelCase]]: input.[[.Name | camelCase]],
+[[- end]]
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update [[.ResourceNameLower]]: %w", err)
+	}
+
+	// For page mode: Exit edit mode and stay on detail view
+	s.IsEditingMode = false
+
+	// Reload the updated resource
+	if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
+		return err
+	}
+
+	// Re-fetch the updated resource for display
+	[[.ResourceNameLower]]s, err := s.Queries.GetAll[[.ResourceNamePlural]](dbCtx)
+	if err == nil {
 		for _, item := range [[.ResourceNameLower]]s {
 			if item.ID == input.ID {
-				s.EditingID = input.ID
 				itemCopy := item
 				s.Editing[[.ResourceName]] = &itemCopy
 				break
 			}
 		}
+	}
 
-	case "update":
-		var input UpdateInput
-		if err := ctx.BindAndValidate(&input, validate); err != nil {
-			return err
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// CancelEdit handles the "cancel_edit" action to cancel editing
+func (s *[[.ResourceName]]State) CancelEdit(_ *livetemplate.ActionContext) error {
+	s.EditingID = ""
+	s.Editing[[.ResourceName]] = nil
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// View handles the "view" action to view a resource
+func (s *[[.ResourceName]]State) View(ctx *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
+
+	var input DeleteInput
+	if err := ctx.BindAndValidate(&input, validate); err != nil {
+		return err
+	}
+
+	// Find the item to view/edit
+	[[.ResourceNameLower]]s, err := s.Queries.GetAll[[.ResourceNamePlural]](dbCtx)
+	if err != nil {
+		return fmt.Errorf("failed to load [[.ResourceNameLower]]s: %w", err)
+	}
+
+	for _, item := range [[.ResourceNameLower]]s {
+		if item.ID == input.ID {
+			s.EditingID = input.ID
+			itemCopy := item
+			s.Editing[[.ResourceName]] = &itemCopy
+			break
 		}
+	}
 
-		err := s.Queries.Update[[.ResourceNameSingular]](dbCtx, models.Update[[.ResourceNameSingular]]Params{
-			ID: input.ID,
-[[- range .Fields]]
-			[[.Name | camelCase]]: input.[[.Name | camelCase]],
-[[- end]]
-		})
-		if err != nil {
-			return fmt.Errorf("failed to update [[.ResourceNameLower]]: %w", err)
-		}
+	s.LastUpdated = formatTime()
+	return nil
+}
 
-		// For page mode: Exit edit mode and stay on detail view
-		s.IsEditingMode = false
+// Back handles the "back" action to return to list view
+func (s *[[.ResourceName]]State) Back(_ *livetemplate.ActionContext) error {
+	s.EditingID = ""
+	s.Editing[[.ResourceName]] = nil
+	s.LastUpdated = formatTime()
+	return nil
+}
 
-		// Reload the updated resource
-		if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
-			return err
-		}
+// Delete handles the "delete" action to remove a resource
+func (s *[[.ResourceName]]State) Delete(ctx *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
 
-		// Re-fetch the updated resource for display
-		[[.ResourceNameLower]]s, err := s.Queries.GetAll[[.ResourceNamePlural]](dbCtx)
-		if err == nil {
-			for _, item := range [[.ResourceNameLower]]s {
-				if item.ID == input.ID {
-					itemCopy := item
-					s.Editing[[.ResourceName]] = &itemCopy
-					break
-				}
+	var input DeleteInput
+	if err := ctx.BindAndValidate(&input, validate); err != nil {
+		return err
+	}
+
+	err := s.Queries.Delete[[.ResourceNameSingular]](dbCtx, input.ID)
+	if err != nil {
+		return fmt.Errorf("failed to delete [[.ResourceNameLower]]: %w", err)
+	}
+
+	// Clear editing state (for page mode)
+	s.EditingID = ""
+	s.Editing[[.ResourceName]] = nil
+
+	if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
+		return err
+	}
+
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// Search handles the "search" action to filter resources
+func (s *[[.ResourceName]]State) Search(ctx *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
+
+	var input SearchInput
+	if err := ctx.BindAndValidate(&input, validate); err != nil {
+		return err
+	}
+	s.SearchQuery = input.Query
+	// Reset infinite scroll when searching
+	if s.PaginationMode == "infinite" || s.PaginationMode == "load-more" {
+		s.LoadedCount = s.PageSize
+	}
+
+	if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
+		return err
+	}
+
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// Sort handles the "sort" action to sort resources
+func (s *[[.ResourceName]]State) Sort(ctx *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
+
+	var input SortInput
+	if err := ctx.BindAndValidate(&input, validate); err != nil {
+		return err
+	}
+	s.SortBy = input.SortBy
+	// Reset infinite scroll when sorting
+	if s.PaginationMode == "infinite" || s.PaginationMode == "load-more" {
+		s.LoadedCount = s.PageSize
+	}
+
+	if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
+		return err
+	}
+
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// NextPage handles the "next_page" action for pagination
+func (s *[[.ResourceName]]State) NextPage(_ *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
+
+	if s.CurrentPage < s.TotalPages {
+		s.CurrentPage++
+	}
+	if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
+		return err
+	}
+
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// PrevPage handles the "prev_page" action for pagination
+func (s *[[.ResourceName]]State) PrevPage(_ *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
+
+	if s.CurrentPage > 1 {
+		s.CurrentPage--
+	}
+	if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
+		return err
+	}
+
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// GotoPage handles the "goto_page" action to jump to a specific page
+func (s *[[.ResourceName]]State) GotoPage(ctx *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
+
+	var input PaginationInput
+	if err := ctx.BindAndValidate(&input, validate); err != nil {
+		return err
+	}
+	if input.Page >= 1 && input.Page <= s.TotalPages {
+		s.CurrentPage = input.Page
+	}
+	if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
+		return err
+	}
+
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// LoadMore handles the "load_more" action for infinite scroll
+func (s *[[.ResourceName]]State) LoadMore(_ *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
+
+	if s.PaginationMode == "infinite" || s.PaginationMode == "load-more" {
+		if s.HasMore && !s.IsLoading {
+			s.IsLoading = true
+			s.LoadedCount += s.PageSize
+			if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
+				return err
 			}
+			s.IsLoading = false
 		}
-
-	case "cancel_edit":
-		s.EditingID = ""
-		s.Editing[[.ResourceName]] = nil
-
-	case "view":
-		var input DeleteInput
-		if err := ctx.BindAndValidate(&input, validate); err != nil {
-			return err
-		}
-
-		// Find the item to view/edit
-		[[.ResourceNameLower]]s, err := s.Queries.GetAll[[.ResourceNamePlural]](dbCtx)
-		if err != nil {
-			return fmt.Errorf("failed to load [[.ResourceNameLower]]s: %w", err)
-		}
-
-		for _, item := range [[.ResourceNameLower]]s {
-			if item.ID == input.ID {
-				s.EditingID = input.ID
-				itemCopy := item
-				s.Editing[[.ResourceName]] = &itemCopy
-				break
-			}
-		}
-
-	case "back":
-		// Return to list view
-		s.EditingID = ""
-		s.Editing[[.ResourceName]] = nil
-
-	case "delete":
-		var input DeleteInput
-		if err := ctx.BindAndValidate(&input, validate); err != nil {
-			return err
-		}
-
-		err := s.Queries.Delete[[.ResourceNameSingular]](dbCtx, input.ID)
-		if err != nil {
-			return fmt.Errorf("failed to delete [[.ResourceNameLower]]: %w", err)
-		}
-
-		// Clear editing state (for page mode)
-		s.EditingID = ""
-		s.Editing[[.ResourceName]] = nil
-
-		if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
-			return err
-		}
-
-	case "search":
-		var input SearchInput
-		if err := ctx.BindAndValidate(&input, validate); err != nil {
-			return err
-		}
-		s.SearchQuery = input.Query
-		// Reset infinite scroll when searching
-		if s.PaginationMode == "infinite" || s.PaginationMode == "load-more" {
-			s.LoadedCount = s.PageSize
-		}
-
-		if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
-			return err
-		}
-
-	case "sort":
-		var input SortInput
-		if err := ctx.BindAndValidate(&input, validate); err != nil {
-			return err
-		}
-		s.SortBy = input.SortBy
-		// Reset infinite scroll when sorting
-		if s.PaginationMode == "infinite" || s.PaginationMode == "load-more" {
-			s.LoadedCount = s.PageSize
-		}
-
-		if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
-			return err
-		}
-
-	case "next_page":
-		if s.CurrentPage < s.TotalPages {
-			s.CurrentPage++
-		}
-		if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
-			return err
-		}
-
-	case "prev_page":
-		if s.CurrentPage > 1 {
-			s.CurrentPage--
-		}
-		if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
-			return err
-		}
-
-	case "goto_page":
-		var input PaginationInput
-		if err := ctx.BindAndValidate(&input, validate); err != nil {
-			return err
-		}
-		if input.Page >= 1 && input.Page <= s.TotalPages {
-			s.CurrentPage = input.Page
-		}
-		if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
-			return err
-		}
-
-	case "load_more":
-		if s.PaginationMode == "infinite" || s.PaginationMode == "load-more" {
-			if s.HasMore && !s.IsLoading {
-				s.IsLoading = true
-				s.LoadedCount += s.PageSize
-				if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
-					return err
-				}
-				s.IsLoading = false
-			}
-		}
-
-	default:
-		log.Printf("Unknown action: %s", ctx.Action)
-		return nil
 	}
 
 	s.LastUpdated = formatTime()

--- a/internal/generator/templates/view/handler.go.tmpl
+++ b/internal/generator/templates/view/handler.go.tmpl
@@ -14,17 +14,12 @@ type [[.ViewName]]State struct {
 	// Add your state fields here
 }
 
-func (s *[[.ViewName]]State) Change(ctx *livetemplate.ActionContext) error {
-	switch ctx.Action {
-	// Add your actions here
-	default:
-		log.Printf("Unknown action: %s", ctx.Action)
-		return nil
-	}
-
-	s.LastUpdated = formatTime()
-	return nil
-}
+// Add your action methods here. Example:
+// func (s *[[.ViewName]]State) MyAction(ctx *livetemplate.ActionContext) error {
+//     // Handle action
+//     s.LastUpdated = formatTime()
+//     return nil
+// }
 
 func formatTime() string {
 	return time.Now().Format("2006-01-02 15:04:05")

--- a/internal/kits/system/multi/templates/app/home.go.tmpl
+++ b/internal/kits/system/multi/templates/app/home.go.tmpl
@@ -2,7 +2,6 @@ package home
 
 import (
 	"encoding/json"
-	"log"
 	"net/http"
 	"os"
 	"time"
@@ -24,10 +23,7 @@ type Resource struct {
 	Type string `json:"type"`
 }
 
-func (s *HomeState) Change(ctx *livetemplate.ActionContext) error {
-	// No actions for home page yet
-	return nil
-}
+// No action methods needed for home page (static)
 
 // Handler creates an http.Handler for the home page
 func Handler() http.Handler {
@@ -41,10 +37,7 @@ func Handler() http.Handler {
 		CSSFramework: "[[.CSSFramework]]",
 	}
 
-	tmpl, err := livetemplate.New("home", livetemplate.WithDevMode([[.DevMode]]))
-	if err != nil {
-		log.Fatalf("Failed to create template: %v", err)
-	}
+	tmpl := livetemplate.New("home", livetemplate.WithDevMode([[.DevMode]]))
 	return tmpl.Handle(state)
 }
 

--- a/internal/kits/system/multi/templates/auth/handler.go.tmpl
+++ b/internal/kits/system/multi/templates/auth/handler.go.tmpl
@@ -90,35 +90,15 @@ func New{{.StructName}}State(db *sql.DB, emailSender email.EmailSender, baseURL 
 	}
 }
 
-// Change implements the Store interface
-func (s *{{.StructName}}State) Change(ctx *livetemplate.ActionContext) error {
-	switch ctx.Action {
-	{{- if .EnablePassword }}
-	case "register":
-		return s.handleRegister(ctx)
-	case "login":
-		return s.handleLogin(ctx)
-	{{- end }}
-	{{- if .EnableMagicLink }}
-	case "magic-link":
-		return s.handleMagicLink(ctx)
-	{{- end }}
-	{{- if .EnablePasswordReset }}
-	case "forgot-password":
-		return s.handleForgotPassword(ctx)
-	{{- end }}
-	case "switch-view":
-		// Switch between login/register/forgot views
-		view := ctx.GetString("view")
-		if view != "" {
-			s.View = view
-			s.Error = ""
-			s.Success = ""
-		}
-		return nil
-	default:
-		return fmt.Errorf("unknown action: %s", ctx.Action)
+// SwitchView handles the "switch_view" action to switch between login/register/forgot views
+func (s *{{.StructName}}State) SwitchView(ctx *livetemplate.ActionContext) error {
+	view := ctx.GetString("view")
+	if view != "" {
+		s.View = view
+		s.Error = ""
+		s.Success = ""
 	}
+	return nil
 }
 
 {{- if .EnablePassword }}
@@ -128,8 +108,8 @@ type RegisterInput struct {
 	Password string `json:"password" validate:"required,min=8"`
 }
 
-// handleRegister handles user registration
-func (s *{{.StructName}}State) handleRegister(ctx *livetemplate.ActionContext) error {
+// Register handles the "register" action for user registration
+func (s *{{.StructName}}State) Register(ctx *livetemplate.ActionContext) error {
 	var input RegisterInput
 	if err := ctx.BindAndValidate(&input, validate); err != nil {
 		s.Error = "Email and password are required"
@@ -205,8 +185,8 @@ type LoginInput struct {
 	Password string `json:"password" validate:"required"`
 }
 
-// handleLogin handles password-based login
-func (s *{{.StructName}}State) handleLogin(ctx *livetemplate.ActionContext) error {
+// Login handles the "login" action for password-based login
+func (s *{{.StructName}}State) Login(ctx *livetemplate.ActionContext) error {
 	var input LoginInput
 	if err := ctx.BindAndValidate(&input, validate); err != nil {
 		s.Error = "Email and password are required"
@@ -275,8 +255,8 @@ type MagicLinkInput struct {
 	Email string `json:"email" validate:"required,email"`
 }
 
-// handleMagicLink sends a magic link email
-func (s *{{.StructName}}State) handleMagicLink(ctx *livetemplate.ActionContext) error {
+// MagicLink handles the "magic_link" action to send a magic link email
+func (s *{{.StructName}}State) MagicLink(ctx *livetemplate.ActionContext) error {
 	var input MagicLinkInput
 	if err := ctx.BindAndValidate(&input, validate); err != nil {
 		s.Error = "Email is required"
@@ -383,8 +363,8 @@ type ForgotPasswordInput struct {
 	Email string `json:"email" validate:"required,email"`
 }
 
-// handleForgotPassword sends a password reset email
-func (s *{{.StructName}}State) handleForgotPassword(ctx *livetemplate.ActionContext) error {
+// ForgotPassword handles the "forgot_password" action to send a password reset email
+func (s *{{.StructName}}State) ForgotPassword(ctx *livetemplate.ActionContext) error {
 	var input ForgotPasswordInput
 	if err := ctx.BindAndValidate(&input, validate); err != nil {
 		s.Error = "Email is required"

--- a/internal/kits/system/multi/templates/resource/handler.go.tmpl
+++ b/internal/kits/system/multi/templates/resource/handler.go.tmpl
@@ -82,201 +82,286 @@ type [[.ResourceName]]State struct {
 	CSSFramework   string              `json:"-"`               // CSS framework for templates
 }
 
-func (s *[[.ResourceName]]State) Change(ctx *livetemplate.ActionContext) error {
+// Add handles the "add" action to create a new resource
+func (s *[[.ResourceName]]State) Add(ctx *livetemplate.ActionContext) error {
 	dbCtx := context.Background()
 
-	switch ctx.Action {
-	case "add":
-		var input AddInput
-		if err := ctx.BindAndValidate(&input, validate); err != nil {
-			return err
-		}
+	var input AddInput
+	if err := ctx.BindAndValidate(&input, validate); err != nil {
+		return err
+	}
 
-		now := time.Now()
-		id := fmt.Sprintf("[[.ResourceNameLower]]-%d", now.UnixNano())
+	log.Printf("[lvt debug] add input: %+v", input)
 
-		_, err := s.Queries.Create[[.ResourceNameSingular]](dbCtx, models.Create[[.ResourceNameSingular]]Params{
-			ID:        id,
+	now := time.Now()
+	id := fmt.Sprintf("[[.ResourceNameLower]]-%d", now.UnixNano())
+
+	_, err := s.Queries.Create[[.ResourceNameSingular]](dbCtx, models.Create[[.ResourceNameSingular]]Params{
+		ID:        id,
 [[- range .Fields]]
-			[[.Name | camelCase]]: input.[[.Name | camelCase]],
+		[[.Name | camelCase]]: input.[[.Name | camelCase]],
 [[- end]]
-			CreatedAt: now,
-		})
-		if err != nil {
-			return fmt.Errorf("failed to create [[.ResourceNameLower]]: %w", err)
-		}
+		CreatedAt: now,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create [[.ResourceNameLower]]: %w", err)
+	}
 
-		if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
-			return err
-		}
+	if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
+		return err
+	}
 
-	case "edit":
-		var input DeleteInput
-		if err := ctx.BindAndValidate(&input, validate); err != nil {
-			return err
-		}
+	s.LastUpdated = formatTime()
+	return nil
+}
 
-		// Find the item to edit
-		[[.ResourceNameLower]]s, err := s.Queries.GetAll[[.ResourceNamePlural]](dbCtx)
-		if err != nil {
-			return fmt.Errorf("failed to load [[.ResourceNameLower]]s: %w", err)
-		}
+// Edit handles the "edit" action to start editing a resource
+func (s *[[.ResourceName]]State) Edit(ctx *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
 
+	var input DeleteInput
+	if err := ctx.BindAndValidate(&input, validate); err != nil {
+		return err
+	}
+
+	// Find the item to edit
+	[[.ResourceNameLower]]s, err := s.Queries.GetAll[[.ResourceNamePlural]](dbCtx)
+	if err != nil {
+		return fmt.Errorf("failed to load [[.ResourceNameLower]]s: %w", err)
+	}
+
+	for _, item := range [[.ResourceNameLower]]s {
+		if item.ID == input.ID {
+			s.EditingID = input.ID
+			itemCopy := item
+			s.Editing[[.ResourceName]] = &itemCopy
+			break
+		}
+	}
+
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// Update handles the "update" action to save changes to a resource
+func (s *[[.ResourceName]]State) Update(ctx *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
+
+	var input UpdateInput
+	if err := ctx.BindAndValidate(&input, validate); err != nil {
+		return err
+	}
+
+	err := s.Queries.Update[[.ResourceNameSingular]](dbCtx, models.Update[[.ResourceNameSingular]]Params{
+		ID: input.ID,
+[[- range .Fields]]
+		[[.Name | camelCase]]: input.[[.Name | camelCase]],
+[[- end]]
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update [[.ResourceNameLower]]: %w", err)
+	}
+
+	// For page mode: Exit edit mode and stay on detail view
+	s.IsEditingMode = false
+
+	// Reload the updated resource
+	if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
+		return err
+	}
+
+	// Re-fetch the updated resource for display
+	[[.ResourceNameLower]]s, err := s.Queries.GetAll[[.ResourceNamePlural]](dbCtx)
+	if err == nil {
 		for _, item := range [[.ResourceNameLower]]s {
 			if item.ID == input.ID {
-				s.EditingID = input.ID
 				itemCopy := item
 				s.Editing[[.ResourceName]] = &itemCopy
 				break
 			}
 		}
+	}
 
-	case "update":
-		var input UpdateInput
-		if err := ctx.BindAndValidate(&input, validate); err != nil {
-			return err
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// CancelEdit handles the "cancel_edit" action to cancel editing
+func (s *[[.ResourceName]]State) CancelEdit(_ *livetemplate.ActionContext) error {
+	s.EditingID = ""
+	s.Editing[[.ResourceName]] = nil
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// View handles the "view" action to view a resource
+func (s *[[.ResourceName]]State) View(ctx *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
+
+	var input DeleteInput
+	if err := ctx.BindAndValidate(&input, validate); err != nil {
+		return err
+	}
+
+	// Find the item to view/edit
+	[[.ResourceNameLower]]s, err := s.Queries.GetAll[[.ResourceNamePlural]](dbCtx)
+	if err != nil {
+		return fmt.Errorf("failed to load [[.ResourceNameLower]]s: %w", err)
+	}
+
+	for _, item := range [[.ResourceNameLower]]s {
+		if item.ID == input.ID {
+			s.EditingID = input.ID
+			itemCopy := item
+			s.Editing[[.ResourceName]] = &itemCopy
+			break
 		}
+	}
 
-		err := s.Queries.Update[[.ResourceNameSingular]](dbCtx, models.Update[[.ResourceNameSingular]]Params{
-			ID: input.ID,
-[[- range .Fields]]
-			[[.Name | camelCase]]: input.[[.Name | camelCase]],
-[[- end]]
-		})
-		if err != nil {
-			return fmt.Errorf("failed to update [[.ResourceNameLower]]: %w", err)
-		}
+	s.LastUpdated = formatTime()
+	return nil
+}
 
-		// For page mode: Exit edit mode and stay on detail view
-		s.IsEditingMode = false
+// Back handles the "back" action to return to list view
+func (s *[[.ResourceName]]State) Back(_ *livetemplate.ActionContext) error {
+	s.EditingID = ""
+	s.Editing[[.ResourceName]] = nil
+	s.LastUpdated = formatTime()
+	return nil
+}
 
-		// Reload the updated resource
-		if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
-			return err
-		}
+// Delete handles the "delete" action to remove a resource
+func (s *[[.ResourceName]]State) Delete(ctx *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
 
-	case "cancel_edit":
-		s.EditingID = ""
-		s.Editing[[.ResourceName]] = nil
+	var input DeleteInput
+	if err := ctx.BindAndValidate(&input, validate); err != nil {
+		return err
+	}
 
-	case "view":
-		var input DeleteInput
-		if err := ctx.BindAndValidate(&input, validate); err != nil {
-			return err
-		}
+	err := s.Queries.Delete[[.ResourceNameSingular]](dbCtx, input.ID)
+	if err != nil {
+		return fmt.Errorf("failed to delete [[.ResourceNameLower]]: %w", err)
+	}
 
-		// Find the item to view/edit
-		[[.ResourceNameLower]]s, err := s.Queries.GetAll[[.ResourceNamePlural]](dbCtx)
-		if err != nil {
-			return fmt.Errorf("failed to load [[.ResourceNameLower]]s: %w", err)
-		}
+	// Clear editing state (for page mode)
+	s.EditingID = ""
+	s.Editing[[.ResourceName]] = nil
 
-		for _, item := range [[.ResourceNameLower]]s {
-			if item.ID == input.ID {
-				s.EditingID = input.ID
-				itemCopy := item
-				s.Editing[[.ResourceName]] = &itemCopy
-				break
+	if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
+		return err
+	}
+
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// Search handles the "search" action to filter resources
+func (s *[[.ResourceName]]State) Search(ctx *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
+
+	var input SearchInput
+	if err := ctx.BindAndValidate(&input, validate); err != nil {
+		return err
+	}
+	s.SearchQuery = input.Query
+	// Reset infinite scroll when searching
+	if s.PaginationMode == "infinite" || s.PaginationMode == "load-more" {
+		s.LoadedCount = s.PageSize
+	}
+
+	if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
+		return err
+	}
+
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// Sort handles the "sort" action to sort resources
+func (s *[[.ResourceName]]State) Sort(ctx *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
+
+	var input SortInput
+	if err := ctx.BindAndValidate(&input, validate); err != nil {
+		return err
+	}
+	s.SortBy = input.SortBy
+	// Reset infinite scroll when sorting
+	if s.PaginationMode == "infinite" || s.PaginationMode == "load-more" {
+		s.LoadedCount = s.PageSize
+	}
+
+	if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
+		return err
+	}
+
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// NextPage handles the "next_page" action for pagination
+func (s *[[.ResourceName]]State) NextPage(_ *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
+
+	if s.CurrentPage < s.TotalPages {
+		s.CurrentPage++
+	}
+	if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
+		return err
+	}
+
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// PrevPage handles the "prev_page" action for pagination
+func (s *[[.ResourceName]]State) PrevPage(_ *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
+
+	if s.CurrentPage > 1 {
+		s.CurrentPage--
+	}
+	if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
+		return err
+	}
+
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// GotoPage handles the "goto_page" action to jump to a specific page
+func (s *[[.ResourceName]]State) GotoPage(ctx *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
+
+	var input PaginationInput
+	if err := ctx.BindAndValidate(&input, validate); err != nil {
+		return err
+	}
+	if input.Page >= 1 && input.Page <= s.TotalPages {
+		s.CurrentPage = input.Page
+	}
+	if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
+		return err
+	}
+
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// LoadMore handles the "load_more" action for infinite scroll
+func (s *[[.ResourceName]]State) LoadMore(_ *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
+
+	if s.PaginationMode == "infinite" || s.PaginationMode == "load-more" {
+		if s.HasMore && !s.IsLoading {
+			s.IsLoading = true
+			s.LoadedCount += s.PageSize
+			if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
+				return err
 			}
+			s.IsLoading = false
 		}
-
-	case "back":
-		// Return to list view
-		s.EditingID = ""
-		s.Editing[[.ResourceName]] = nil
-
-	case "delete":
-		var input DeleteInput
-		if err := ctx.BindAndValidate(&input, validate); err != nil {
-			return err
-		}
-
-		err := s.Queries.Delete[[.ResourceNameSingular]](dbCtx, input.ID)
-		if err != nil {
-			return fmt.Errorf("failed to delete [[.ResourceNameLower]]: %w", err)
-		}
-
-		// Clear editing state (for page mode)
-		s.EditingID = ""
-		s.Editing[[.ResourceName]] = nil
-
-		if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
-			return err
-		}
-
-	case "search":
-		var input SearchInput
-		if err := ctx.BindAndValidate(&input, validate); err != nil {
-			return err
-		}
-		s.SearchQuery = input.Query
-		// Reset infinite scroll when searching
-		if s.PaginationMode == "infinite" || s.PaginationMode == "load-more" {
-			s.LoadedCount = s.PageSize
-		}
-
-		if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
-			return err
-		}
-
-	case "sort":
-		var input SortInput
-		if err := ctx.BindAndValidate(&input, validate); err != nil {
-			return err
-		}
-		s.SortBy = input.SortBy
-		// Reset infinite scroll when sorting
-		if s.PaginationMode == "infinite" || s.PaginationMode == "load-more" {
-			s.LoadedCount = s.PageSize
-		}
-
-		if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
-			return err
-		}
-
-	case "next_page":
-		if s.CurrentPage < s.TotalPages {
-			s.CurrentPage++
-		}
-		if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
-			return err
-		}
-
-	case "prev_page":
-		if s.CurrentPage > 1 {
-			s.CurrentPage--
-		}
-		if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
-			return err
-		}
-
-	case "goto_page":
-		var input PaginationInput
-		if err := ctx.BindAndValidate(&input, validate); err != nil {
-			return err
-		}
-		if input.Page >= 1 && input.Page <= s.TotalPages {
-			s.CurrentPage = input.Page
-		}
-		if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
-			return err
-		}
-
-	case "load_more":
-		if s.PaginationMode == "infinite" || s.PaginationMode == "load-more" {
-			if s.HasMore && !s.IsLoading {
-				s.IsLoading = true
-				s.LoadedCount += s.PageSize
-				if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
-					return err
-				}
-				s.IsLoading = false
-			}
-		}
-
-	default:
-		log.Printf("Unknown action: %s", ctx.Action)
-		return nil
 	}
 
 	s.LastUpdated = formatTime()
@@ -284,10 +369,6 @@ func (s *[[.ResourceName]]State) Change(ctx *livetemplate.ActionContext) error {
 }
 
 func (s *[[.ResourceName]]State) Init() error {
-	// Clear any editing state from previous session (but preserve if already set for URL routing)
-	if s.EditingID == "" {
-		s.Editing[[.ResourceName]] = nil
-	}
 	return s.load[[.ResourceName]]s(context.Background())
 }
 
@@ -424,10 +505,7 @@ func Handler(queries *models.Queries) http.Handler {
 		log.Printf("Failed to initialize [[.ResourceNameLower]] state: %v", err)
 	}
 
-	baseTmpl, err := livetemplate.New("[[.ResourceNameLower]]", livetemplate.WithDevMode([[.DevMode]]))
-	if err != nil {
-		log.Fatalf("Failed to create template: %v", err)
-	}
+	baseTmpl := livetemplate.New("[[.ResourceNameLower]]", livetemplate.WithDevMode([[.DevMode]]))
 	if _, err := baseTmpl.ParseFiles("internal/app/[[.ResourceNameLower]]/[[.ResourceNameLower]].tmpl"); err != nil {
 		log.Fatalf("Failed to parse template: %v", err)
 	}
@@ -471,27 +549,24 @@ func Handler(queries *models.Queries) http.Handler {
 				LastUpdated:    formatTime(),
 				CSSFramework:   "[[.CSSFramework]]",
 				IsEditingMode:  isEditMode,
-				EditingID:      resourceID, // Set EditingID before Init to prevent it from being cleared
 			}
 
-			// Find and set the editing resource BEFORE calling Init
-			[[.ResourceNameLower]]s, err := queries.GetAll[[.ResourceNamePlural]](context.Background())
-			if err == nil {
-				for _, item := range [[.ResourceNameLower]]s {
-					if item.ID == resourceID {
-						itemCopy := item
-						resourceState.Editing[[.ResourceName]] = &itemCopy
-						break
+			if err := resourceState.Init(); err == nil {
+				// Find and set the editing resource
+				[[.ResourceNameLower]]s, err := queries.GetAll[[.ResourceNamePlural]](context.Background())
+				if err == nil {
+					for _, item := range [[.ResourceNameLower]]s {
+						if item.ID == resourceID {
+							resourceState.EditingID = resourceID
+							itemCopy := item
+							resourceState.Editing[[.ResourceName]] = &itemCopy
+							break
+						}
 					}
 				}
 			}
 
-			// Initialize the state (will load all resources but preserve EditingID/Editing[[.ResourceName]])
-			if err := resourceState.Init(); err != nil {
-				log.Printf("Failed to initialize resource state: %v", err)
-			}
-
-			// Handle with custom state
+			// Mount with custom state
 			tmpl, err := baseTmpl.Clone()
 			if err != nil {
 				log.Printf("Failed to clone template: %v", err)

--- a/internal/kits/system/multi/templates/view/handler.go.tmpl
+++ b/internal/kits/system/multi/templates/view/handler.go.tmpl
@@ -14,17 +14,12 @@ type [[.ViewName]]State struct {
 	// Add your state fields here
 }
 
-func (s *[[.ViewName]]State) Change(ctx *livetemplate.ActionContext) error {
-	switch ctx.Action {
-	// Add your actions here
-	default:
-		log.Printf("Unknown action: %s", ctx.Action)
-		return nil
-	}
-
-	s.LastUpdated = formatTime()
-	return nil
-}
+// Add your action methods here. Example:
+// func (s *[[.ViewName]]State) MyAction(ctx *livetemplate.ActionContext) error {
+//     // Handle action
+//     s.LastUpdated = formatTime()
+//     return nil
+// }
 
 func formatTime() string {
 	return time.Now().Format("2006-01-02 15:04:05")

--- a/internal/kits/system/simple/templates/app/main.go.tmpl
+++ b/internal/kits/system/simple/templates/app/main.go.tmpl
@@ -15,19 +15,23 @@ type AppState struct {
 	LastUpdated string `json:"last_updated"`
 }
 
-func (s *AppState) Change(ctx *livetemplate.ActionContext) error {
-	switch ctx.Action {
-	case "increment":
-		s.Counter++
-	case "decrement":
-		s.Counter--
-	case "reset":
-		s.Counter = 0
-	default:
-		log.Printf("Unknown action: %s", ctx.Action)
-		return nil
-	}
+// Increment handles the "increment" action
+func (s *AppState) Increment(_ *livetemplate.ActionContext) error {
+	s.Counter++
+	s.LastUpdated = formatTime()
+	return nil
+}
 
+// Decrement handles the "decrement" action
+func (s *AppState) Decrement(_ *livetemplate.ActionContext) error {
+	s.Counter--
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// Reset handles the "reset" action
+func (s *AppState) Reset(_ *livetemplate.ActionContext) error {
+	s.Counter = 0
 	s.LastUpdated = formatTime()
 	return nil
 }

--- a/internal/kits/system/single/templates/app/home.go.tmpl
+++ b/internal/kits/system/single/templates/app/home.go.tmpl
@@ -2,7 +2,6 @@ package home
 
 import (
 	"encoding/json"
-	"log"
 	"net/http"
 	"os"
 	"time"
@@ -24,10 +23,7 @@ type Resource struct {
 	Type string `json:"type"`
 }
 
-func (s *HomeState) Change(ctx *livetemplate.ActionContext) error {
-	// No actions for home page yet
-	return nil
-}
+// No action methods needed for home page (static)
 
 // Handler creates an http.Handler for the home page
 func Handler() http.Handler {
@@ -41,10 +37,7 @@ func Handler() http.Handler {
 		CSSFramework: "[[.CSSFramework]]",
 	}
 
-	tmpl, err := livetemplate.New("home", livetemplate.WithDevMode([[.DevMode]]))
-	if err != nil {
-		log.Fatalf("Failed to create template: %v", err)
-	}
+	tmpl := livetemplate.New("home", livetemplate.WithDevMode([[.DevMode]]))
 	return tmpl.Handle(state)
 }
 

--- a/internal/kits/system/single/templates/resource/handler.go.tmpl
+++ b/internal/kits/system/single/templates/resource/handler.go.tmpl
@@ -82,213 +82,286 @@ type [[.ResourceName]]State struct {
 	CSSFramework   string              `json:"-"`               // CSS framework for templates
 }
 
-func (s *[[.ResourceName]]State) Change(ctx *livetemplate.ActionContext) error {
+// Add handles the "add" action to create a new resource
+func (s *[[.ResourceName]]State) Add(ctx *livetemplate.ActionContext) error {
 	dbCtx := context.Background()
 
-	switch ctx.Action {
-	case "add":
-		var input AddInput
-		if err := ctx.BindAndValidate(&input, validate); err != nil {
-			return err
-		}
+	var input AddInput
+	if err := ctx.BindAndValidate(&input, validate); err != nil {
+		return err
+	}
 
-		now := time.Now()
-		id := fmt.Sprintf("[[.ResourceNameLower]]-%d", now.UnixNano())
+	log.Printf("[lvt debug] add input: %+v", input)
 
-		_, err := s.Queries.Create[[.ResourceNameSingular]](dbCtx, models.Create[[.ResourceNameSingular]]Params{
-			ID:        id,
+	now := time.Now()
+	id := fmt.Sprintf("[[.ResourceNameLower]]-%d", now.UnixNano())
+
+	_, err := s.Queries.Create[[.ResourceNameSingular]](dbCtx, models.Create[[.ResourceNameSingular]]Params{
+		ID:        id,
 [[- range .Fields]]
-			[[.Name | camelCase]]: input.[[.Name | camelCase]],
+		[[.Name | camelCase]]: input.[[.Name | camelCase]],
 [[- end]]
-			CreatedAt: now,
-		})
-		if err != nil {
-			return fmt.Errorf("failed to create [[.ResourceNameLower]]: %w", err)
-		}
+		CreatedAt: now,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create [[.ResourceNameLower]]: %w", err)
+	}
 
-		if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
-			return err
-		}
+	if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
+		return err
+	}
 
-	case "edit":
-		var input DeleteInput
-		if err := ctx.BindAndValidate(&input, validate); err != nil {
-			return err
-		}
+	s.LastUpdated = formatTime()
+	return nil
+}
 
-		// Find the item to edit
-		[[.ResourceNameLower]]s, err := s.Queries.GetAll[[.ResourceNamePlural]](dbCtx)
-		if err != nil {
-			return fmt.Errorf("failed to load [[.ResourceNameLower]]s: %w", err)
-		}
+// Edit handles the "edit" action to start editing a resource
+func (s *[[.ResourceName]]State) Edit(ctx *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
 
+	var input DeleteInput
+	if err := ctx.BindAndValidate(&input, validate); err != nil {
+		return err
+	}
+
+	// Find the item to edit
+	[[.ResourceNameLower]]s, err := s.Queries.GetAll[[.ResourceNamePlural]](dbCtx)
+	if err != nil {
+		return fmt.Errorf("failed to load [[.ResourceNameLower]]s: %w", err)
+	}
+
+	for _, item := range [[.ResourceNameLower]]s {
+		if item.ID == input.ID {
+			s.EditingID = input.ID
+			itemCopy := item
+			s.Editing[[.ResourceName]] = &itemCopy
+			break
+		}
+	}
+
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// Update handles the "update" action to save changes to a resource
+func (s *[[.ResourceName]]State) Update(ctx *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
+
+	var input UpdateInput
+	if err := ctx.BindAndValidate(&input, validate); err != nil {
+		return err
+	}
+
+	err := s.Queries.Update[[.ResourceNameSingular]](dbCtx, models.Update[[.ResourceNameSingular]]Params{
+		ID: input.ID,
+[[- range .Fields]]
+		[[.Name | camelCase]]: input.[[.Name | camelCase]],
+[[- end]]
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update [[.ResourceNameLower]]: %w", err)
+	}
+
+	// For page mode: Exit edit mode and stay on detail view
+	s.IsEditingMode = false
+
+	// Reload the updated resource
+	if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
+		return err
+	}
+
+	// Re-fetch the updated resource for display
+	[[.ResourceNameLower]]s, err := s.Queries.GetAll[[.ResourceNamePlural]](dbCtx)
+	if err == nil {
 		for _, item := range [[.ResourceNameLower]]s {
 			if item.ID == input.ID {
-				s.EditingID = input.ID
 				itemCopy := item
 				s.Editing[[.ResourceName]] = &itemCopy
 				break
 			}
 		}
+	}
 
-	case "update":
-		var input UpdateInput
-		if err := ctx.BindAndValidate(&input, validate); err != nil {
-			return err
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// CancelEdit handles the "cancel_edit" action to cancel editing
+func (s *[[.ResourceName]]State) CancelEdit(_ *livetemplate.ActionContext) error {
+	s.EditingID = ""
+	s.Editing[[.ResourceName]] = nil
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// View handles the "view" action to view a resource
+func (s *[[.ResourceName]]State) View(ctx *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
+
+	var input DeleteInput
+	if err := ctx.BindAndValidate(&input, validate); err != nil {
+		return err
+	}
+
+	// Find the item to view/edit
+	[[.ResourceNameLower]]s, err := s.Queries.GetAll[[.ResourceNamePlural]](dbCtx)
+	if err != nil {
+		return fmt.Errorf("failed to load [[.ResourceNameLower]]s: %w", err)
+	}
+
+	for _, item := range [[.ResourceNameLower]]s {
+		if item.ID == input.ID {
+			s.EditingID = input.ID
+			itemCopy := item
+			s.Editing[[.ResourceName]] = &itemCopy
+			break
 		}
+	}
 
-		err := s.Queries.Update[[.ResourceNameSingular]](dbCtx, models.Update[[.ResourceNameSingular]]Params{
-			ID: input.ID,
-[[- range .Fields]]
-			[[.Name | camelCase]]: input.[[.Name | camelCase]],
-[[- end]]
-		})
-		if err != nil {
-			return fmt.Errorf("failed to update [[.ResourceNameLower]]: %w", err)
-		}
+	s.LastUpdated = formatTime()
+	return nil
+}
 
-		// For page mode: Exit edit mode and stay on detail view
-		s.IsEditingMode = false
+// Back handles the "back" action to return to list view
+func (s *[[.ResourceName]]State) Back(_ *livetemplate.ActionContext) error {
+	s.EditingID = ""
+	s.Editing[[.ResourceName]] = nil
+	s.LastUpdated = formatTime()
+	return nil
+}
 
-		// Reload the updated resource
-		if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
-			return err
-		}
+// Delete handles the "delete" action to remove a resource
+func (s *[[.ResourceName]]State) Delete(ctx *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
 
-		// Re-fetch the updated resource for display
-		[[.ResourceNameLower]]s, err := s.Queries.GetAll[[.ResourceNamePlural]](dbCtx)
-		if err == nil {
-			for _, item := range [[.ResourceNameLower]]s {
-				if item.ID == input.ID {
-					itemCopy := item
-					s.Editing[[.ResourceName]] = &itemCopy
-					break
-				}
+	var input DeleteInput
+	if err := ctx.BindAndValidate(&input, validate); err != nil {
+		return err
+	}
+
+	err := s.Queries.Delete[[.ResourceNameSingular]](dbCtx, input.ID)
+	if err != nil {
+		return fmt.Errorf("failed to delete [[.ResourceNameLower]]: %w", err)
+	}
+
+	// Clear editing state (for page mode)
+	s.EditingID = ""
+	s.Editing[[.ResourceName]] = nil
+
+	if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
+		return err
+	}
+
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// Search handles the "search" action to filter resources
+func (s *[[.ResourceName]]State) Search(ctx *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
+
+	var input SearchInput
+	if err := ctx.BindAndValidate(&input, validate); err != nil {
+		return err
+	}
+	s.SearchQuery = input.Query
+	// Reset infinite scroll when searching
+	if s.PaginationMode == "infinite" || s.PaginationMode == "load-more" {
+		s.LoadedCount = s.PageSize
+	}
+
+	if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
+		return err
+	}
+
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// Sort handles the "sort" action to sort resources
+func (s *[[.ResourceName]]State) Sort(ctx *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
+
+	var input SortInput
+	if err := ctx.BindAndValidate(&input, validate); err != nil {
+		return err
+	}
+	s.SortBy = input.SortBy
+	// Reset infinite scroll when sorting
+	if s.PaginationMode == "infinite" || s.PaginationMode == "load-more" {
+		s.LoadedCount = s.PageSize
+	}
+
+	if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
+		return err
+	}
+
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// NextPage handles the "next_page" action for pagination
+func (s *[[.ResourceName]]State) NextPage(_ *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
+
+	if s.CurrentPage < s.TotalPages {
+		s.CurrentPage++
+	}
+	if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
+		return err
+	}
+
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// PrevPage handles the "prev_page" action for pagination
+func (s *[[.ResourceName]]State) PrevPage(_ *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
+
+	if s.CurrentPage > 1 {
+		s.CurrentPage--
+	}
+	if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
+		return err
+	}
+
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// GotoPage handles the "goto_page" action to jump to a specific page
+func (s *[[.ResourceName]]State) GotoPage(ctx *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
+
+	var input PaginationInput
+	if err := ctx.BindAndValidate(&input, validate); err != nil {
+		return err
+	}
+	if input.Page >= 1 && input.Page <= s.TotalPages {
+		s.CurrentPage = input.Page
+	}
+	if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
+		return err
+	}
+
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// LoadMore handles the "load_more" action for infinite scroll
+func (s *[[.ResourceName]]State) LoadMore(_ *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
+
+	if s.PaginationMode == "infinite" || s.PaginationMode == "load-more" {
+		if s.HasMore && !s.IsLoading {
+			s.IsLoading = true
+			s.LoadedCount += s.PageSize
+			if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
+				return err
 			}
+			s.IsLoading = false
 		}
-
-	case "cancel_edit":
-		s.EditingID = ""
-		s.Editing[[.ResourceName]] = nil
-
-	case "view":
-		var input DeleteInput
-		if err := ctx.BindAndValidate(&input, validate); err != nil {
-			return err
-		}
-
-		// Find the item to view/edit
-		[[.ResourceNameLower]]s, err := s.Queries.GetAll[[.ResourceNamePlural]](dbCtx)
-		if err != nil {
-			return fmt.Errorf("failed to load [[.ResourceNameLower]]s: %w", err)
-		}
-
-		for _, item := range [[.ResourceNameLower]]s {
-			if item.ID == input.ID {
-				s.EditingID = input.ID
-				itemCopy := item
-				s.Editing[[.ResourceName]] = &itemCopy
-				break
-			}
-		}
-
-	case "back":
-		// Return to list view
-		s.EditingID = ""
-		s.Editing[[.ResourceName]] = nil
-
-	case "delete":
-		var input DeleteInput
-		if err := ctx.BindAndValidate(&input, validate); err != nil {
-			return err
-		}
-
-		err := s.Queries.Delete[[.ResourceNameSingular]](dbCtx, input.ID)
-		if err != nil {
-			return fmt.Errorf("failed to delete [[.ResourceNameLower]]: %w", err)
-		}
-
-		// Clear editing state (for page mode)
-		s.EditingID = ""
-		s.Editing[[.ResourceName]] = nil
-
-		if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
-			return err
-		}
-
-	case "search":
-		var input SearchInput
-		if err := ctx.BindAndValidate(&input, validate); err != nil {
-			return err
-		}
-		s.SearchQuery = input.Query
-		// Reset infinite scroll when searching
-		if s.PaginationMode == "infinite" || s.PaginationMode == "load-more" {
-			s.LoadedCount = s.PageSize
-		}
-
-		if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
-			return err
-		}
-
-	case "sort":
-		var input SortInput
-		if err := ctx.BindAndValidate(&input, validate); err != nil {
-			return err
-		}
-		s.SortBy = input.SortBy
-		// Reset infinite scroll when sorting
-		if s.PaginationMode == "infinite" || s.PaginationMode == "load-more" {
-			s.LoadedCount = s.PageSize
-		}
-
-		if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
-			return err
-		}
-
-	case "next_page":
-		if s.CurrentPage < s.TotalPages {
-			s.CurrentPage++
-		}
-		if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
-			return err
-		}
-
-	case "prev_page":
-		if s.CurrentPage > 1 {
-			s.CurrentPage--
-		}
-		if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
-			return err
-		}
-
-	case "goto_page":
-		var input PaginationInput
-		if err := ctx.BindAndValidate(&input, validate); err != nil {
-			return err
-		}
-		if input.Page >= 1 && input.Page <= s.TotalPages {
-			s.CurrentPage = input.Page
-		}
-		if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
-			return err
-		}
-
-	case "load_more":
-		if s.PaginationMode == "infinite" || s.PaginationMode == "load-more" {
-			if s.HasMore && !s.IsLoading {
-				s.IsLoading = true
-				s.LoadedCount += s.PageSize
-				if err := s.load[[.ResourceName]]s(dbCtx); err != nil {
-					return err
-				}
-				s.IsLoading = false
-			}
-		}
-
-	default:
-		log.Printf("Unknown action: %s", ctx.Action)
-		return nil
 	}
 
 	s.LastUpdated = formatTime()

--- a/internal/kits/system/single/templates/view/handler.go.tmpl
+++ b/internal/kits/system/single/templates/view/handler.go.tmpl
@@ -14,17 +14,12 @@ type [[.ViewName]]State struct {
 	// Add your state fields here
 }
 
-func (s *[[.ViewName]]State) Change(ctx *livetemplate.ActionContext) error {
-	switch ctx.Action {
-	// Add your actions here
-	default:
-		log.Printf("Unknown action: %s", ctx.Action)
-		return nil
-	}
-
-	s.LastUpdated = formatTime()
-	return nil
-}
+// Add your action methods here. Example:
+// func (s *[[.ViewName]]State) MyAction(ctx *livetemplate.ActionContext) error {
+//     // Handle action
+//     s.LastUpdated = formatTime()
+//     return nil
+// }
 
 func formatTime() string {
 	return time.Now().Format("2006-01-02 15:04:05")

--- a/testdata/golden/resource_handler.go.golden
+++ b/testdata/golden/resource_handler.go.golden
@@ -68,199 +68,284 @@ type UserState struct {
 	CSSFramework   string              `json:"-"`               // CSS framework for templates
 }
 
-func (s *UserState) Change(ctx *livetemplate.ActionContext) error {
+// Add handles the "add" action to create a new resource
+func (s *UserState) Add(ctx *livetemplate.ActionContext) error {
 	dbCtx := context.Background()
 
-	switch ctx.Action {
-	case "add":
-		var input AddInput
-		if err := ctx.BindAndValidate(&input, validate); err != nil {
-			return err
+	var input AddInput
+	if err := ctx.BindAndValidate(&input, validate); err != nil {
+		return err
+	}
+
+	log.Printf("[lvt debug] add input: %+v", input)
+
+	now := time.Now()
+	id := fmt.Sprintf("user-%d", now.UnixNano())
+
+	_, err := s.Queries.CreateUser(dbCtx, models.CreateUserParams{
+		ID:        id,
+		Name: input.Name,
+		Age: input.Age,
+		CreatedAt: now,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create user: %w", err)
+	}
+
+	if err := s.loadUsers(dbCtx); err != nil {
+		return err
+	}
+
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// Edit handles the "edit" action to start editing a resource
+func (s *UserState) Edit(ctx *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
+
+	var input DeleteInput
+	if err := ctx.BindAndValidate(&input, validate); err != nil {
+		return err
+	}
+
+	// Find the item to edit
+	users, err := s.Queries.GetAllUsers(dbCtx)
+	if err != nil {
+		return fmt.Errorf("failed to load users: %w", err)
+	}
+
+	for _, item := range users {
+		if item.ID == input.ID {
+			s.EditingID = input.ID
+			itemCopy := item
+			s.EditingUser = &itemCopy
+			break
 		}
+	}
 
-		now := time.Now()
-		id := fmt.Sprintf("user-%d", now.UnixNano())
+	s.LastUpdated = formatTime()
+	return nil
+}
 
-		_, err := s.Queries.CreateUser(dbCtx, models.CreateUserParams{
-			ID:        id,
-			Name: input.Name,
-			Age: input.Age,
-			CreatedAt: now,
-		})
-		if err != nil {
-			return fmt.Errorf("failed to create user: %w", err)
-		}
+// Update handles the "update" action to save changes to a resource
+func (s *UserState) Update(ctx *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
 
-		if err := s.loadUsers(dbCtx); err != nil {
-			return err
-		}
+	var input UpdateInput
+	if err := ctx.BindAndValidate(&input, validate); err != nil {
+		return err
+	}
 
-	case "edit":
-		var input DeleteInput
-		if err := ctx.BindAndValidate(&input, validate); err != nil {
-			return err
-		}
+	err := s.Queries.UpdateUser(dbCtx, models.UpdateUserParams{
+		ID: input.ID,
+		Name: input.Name,
+		Age: input.Age,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update user: %w", err)
+	}
 
-		// Find the item to edit
-		users, err := s.Queries.GetAllUsers(dbCtx)
-		if err != nil {
-			return fmt.Errorf("failed to load users: %w", err)
-		}
+	// For page mode: Exit edit mode and stay on detail view
+	s.IsEditingMode = false
 
+	// Reload the updated resource
+	if err := s.loadUsers(dbCtx); err != nil {
+		return err
+	}
+
+	// Re-fetch the updated resource for display
+	users, err := s.Queries.GetAllUsers(dbCtx)
+	if err == nil {
 		for _, item := range users {
 			if item.ID == input.ID {
-				s.EditingID = input.ID
 				itemCopy := item
 				s.EditingUser = &itemCopy
 				break
 			}
 		}
+	}
 
-	case "update":
-		var input UpdateInput
-		if err := ctx.BindAndValidate(&input, validate); err != nil {
-			return err
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// CancelEdit handles the "cancel_edit" action to cancel editing
+func (s *UserState) CancelEdit(_ *livetemplate.ActionContext) error {
+	s.EditingID = ""
+	s.EditingUser = nil
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// View handles the "view" action to view a resource
+func (s *UserState) View(ctx *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
+
+	var input DeleteInput
+	if err := ctx.BindAndValidate(&input, validate); err != nil {
+		return err
+	}
+
+	// Find the item to view/edit
+	users, err := s.Queries.GetAllUsers(dbCtx)
+	if err != nil {
+		return fmt.Errorf("failed to load users: %w", err)
+	}
+
+	for _, item := range users {
+		if item.ID == input.ID {
+			s.EditingID = input.ID
+			itemCopy := item
+			s.EditingUser = &itemCopy
+			break
 		}
+	}
 
-		err := s.Queries.UpdateUser(dbCtx, models.UpdateUserParams{
-			ID: input.ID,
-			Name: input.Name,
-			Age: input.Age,
-		})
-		if err != nil {
-			return fmt.Errorf("failed to update user: %w", err)
-		}
+	s.LastUpdated = formatTime()
+	return nil
+}
 
-		// For page mode: Exit edit mode and stay on detail view
-		s.IsEditingMode = false
+// Back handles the "back" action to return to list view
+func (s *UserState) Back(_ *livetemplate.ActionContext) error {
+	s.EditingID = ""
+	s.EditingUser = nil
+	s.LastUpdated = formatTime()
+	return nil
+}
 
-		// Reload the updated resource
-		if err := s.loadUsers(dbCtx); err != nil {
-			return err
-		}
+// Delete handles the "delete" action to remove a resource
+func (s *UserState) Delete(ctx *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
 
-	case "cancel_edit":
-		s.EditingID = ""
-		s.EditingUser = nil
+	var input DeleteInput
+	if err := ctx.BindAndValidate(&input, validate); err != nil {
+		return err
+	}
 
-	case "view":
-		var input DeleteInput
-		if err := ctx.BindAndValidate(&input, validate); err != nil {
-			return err
-		}
+	err := s.Queries.DeleteUser(dbCtx, input.ID)
+	if err != nil {
+		return fmt.Errorf("failed to delete user: %w", err)
+	}
 
-		// Find the item to view/edit
-		users, err := s.Queries.GetAllUsers(dbCtx)
-		if err != nil {
-			return fmt.Errorf("failed to load users: %w", err)
-		}
+	// Clear editing state (for page mode)
+	s.EditingID = ""
+	s.EditingUser = nil
 
-		for _, item := range users {
-			if item.ID == input.ID {
-				s.EditingID = input.ID
-				itemCopy := item
-				s.EditingUser = &itemCopy
-				break
+	if err := s.loadUsers(dbCtx); err != nil {
+		return err
+	}
+
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// Search handles the "search" action to filter resources
+func (s *UserState) Search(ctx *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
+
+	var input SearchInput
+	if err := ctx.BindAndValidate(&input, validate); err != nil {
+		return err
+	}
+	s.SearchQuery = input.Query
+	// Reset infinite scroll when searching
+	if s.PaginationMode == "infinite" || s.PaginationMode == "load-more" {
+		s.LoadedCount = s.PageSize
+	}
+
+	if err := s.loadUsers(dbCtx); err != nil {
+		return err
+	}
+
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// Sort handles the "sort" action to sort resources
+func (s *UserState) Sort(ctx *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
+
+	var input SortInput
+	if err := ctx.BindAndValidate(&input, validate); err != nil {
+		return err
+	}
+	s.SortBy = input.SortBy
+	// Reset infinite scroll when sorting
+	if s.PaginationMode == "infinite" || s.PaginationMode == "load-more" {
+		s.LoadedCount = s.PageSize
+	}
+
+	if err := s.loadUsers(dbCtx); err != nil {
+		return err
+	}
+
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// NextPage handles the "next_page" action for pagination
+func (s *UserState) NextPage(_ *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
+
+	if s.CurrentPage < s.TotalPages {
+		s.CurrentPage++
+	}
+	if err := s.loadUsers(dbCtx); err != nil {
+		return err
+	}
+
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// PrevPage handles the "prev_page" action for pagination
+func (s *UserState) PrevPage(_ *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
+
+	if s.CurrentPage > 1 {
+		s.CurrentPage--
+	}
+	if err := s.loadUsers(dbCtx); err != nil {
+		return err
+	}
+
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// GotoPage handles the "goto_page" action to jump to a specific page
+func (s *UserState) GotoPage(ctx *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
+
+	var input PaginationInput
+	if err := ctx.BindAndValidate(&input, validate); err != nil {
+		return err
+	}
+	if input.Page >= 1 && input.Page <= s.TotalPages {
+		s.CurrentPage = input.Page
+	}
+	if err := s.loadUsers(dbCtx); err != nil {
+		return err
+	}
+
+	s.LastUpdated = formatTime()
+	return nil
+}
+
+// LoadMore handles the "load_more" action for infinite scroll
+func (s *UserState) LoadMore(_ *livetemplate.ActionContext) error {
+	dbCtx := context.Background()
+
+	if s.PaginationMode == "infinite" || s.PaginationMode == "load-more" {
+		if s.HasMore && !s.IsLoading {
+			s.IsLoading = true
+			s.LoadedCount += s.PageSize
+			if err := s.loadUsers(dbCtx); err != nil {
+				return err
 			}
+			s.IsLoading = false
 		}
-
-	case "back":
-		// Return to list view
-		s.EditingID = ""
-		s.EditingUser = nil
-
-	case "delete":
-		var input DeleteInput
-		if err := ctx.BindAndValidate(&input, validate); err != nil {
-			return err
-		}
-
-		err := s.Queries.DeleteUser(dbCtx, input.ID)
-		if err != nil {
-			return fmt.Errorf("failed to delete user: %w", err)
-		}
-
-		// Clear editing state (for page mode)
-		s.EditingID = ""
-		s.EditingUser = nil
-
-		if err := s.loadUsers(dbCtx); err != nil {
-			return err
-		}
-
-	case "search":
-		var input SearchInput
-		if err := ctx.BindAndValidate(&input, validate); err != nil {
-			return err
-		}
-		s.SearchQuery = input.Query
-		// Reset infinite scroll when searching
-		if s.PaginationMode == "infinite" || s.PaginationMode == "load-more" {
-			s.LoadedCount = s.PageSize
-		}
-
-		if err := s.loadUsers(dbCtx); err != nil {
-			return err
-		}
-
-	case "sort":
-		var input SortInput
-		if err := ctx.BindAndValidate(&input, validate); err != nil {
-			return err
-		}
-		s.SortBy = input.SortBy
-		// Reset infinite scroll when sorting
-		if s.PaginationMode == "infinite" || s.PaginationMode == "load-more" {
-			s.LoadedCount = s.PageSize
-		}
-
-		if err := s.loadUsers(dbCtx); err != nil {
-			return err
-		}
-
-	case "next_page":
-		if s.CurrentPage < s.TotalPages {
-			s.CurrentPage++
-		}
-		if err := s.loadUsers(dbCtx); err != nil {
-			return err
-		}
-
-	case "prev_page":
-		if s.CurrentPage > 1 {
-			s.CurrentPage--
-		}
-		if err := s.loadUsers(dbCtx); err != nil {
-			return err
-		}
-
-	case "goto_page":
-		var input PaginationInput
-		if err := ctx.BindAndValidate(&input, validate); err != nil {
-			return err
-		}
-		if input.Page >= 1 && input.Page <= s.TotalPages {
-			s.CurrentPage = input.Page
-		}
-		if err := s.loadUsers(dbCtx); err != nil {
-			return err
-		}
-
-	case "load_more":
-		if s.PaginationMode == "infinite" || s.PaginationMode == "load-more" {
-			if s.HasMore && !s.IsLoading {
-				s.IsLoading = true
-				s.LoadedCount += s.PageSize
-				if err := s.loadUsers(dbCtx); err != nil {
-					return err
-				}
-				s.IsLoading = false
-			}
-		}
-
-	default:
-		log.Printf("Unknown action: %s", ctx.Action)
-		return nil
 	}
 
 	s.LastUpdated = formatTime()
@@ -268,10 +353,6 @@ func (s *UserState) Change(ctx *livetemplate.ActionContext) error {
 }
 
 func (s *UserState) Init() error {
-	// Clear any editing state from previous session (but preserve if already set for URL routing)
-	if s.EditingID == "" {
-		s.EditingUser = nil
-	}
 	return s.loadUsers(context.Background())
 }
 
@@ -400,10 +481,7 @@ func Handler(queries *models.Queries) http.Handler {
 		log.Printf("Failed to initialize user state: %v", err)
 	}
 
-	baseTmpl, err := livetemplate.New("user", livetemplate.WithDevMode(false))
-	if err != nil {
-		log.Fatalf("Failed to create template: %v", err)
-	}
+	baseTmpl := livetemplate.New("user", livetemplate.WithDevMode(false))
 	if _, err := baseTmpl.ParseFiles("internal/app/user/user.tmpl"); err != nil {
 		log.Fatalf("Failed to parse template: %v", err)
 	}

--- a/testdata/golden/view_handler.go.golden
+++ b/testdata/golden/view_handler.go.golden
@@ -14,17 +14,12 @@ type CounterState struct {
 	// Add your state fields here
 }
 
-func (s *CounterState) Change(ctx *livetemplate.ActionContext) error {
-	switch ctx.Action {
-	// Add your actions here
-	default:
-		log.Printf("Unknown action: %s", ctx.Action)
-		return nil
-	}
-
-	s.LastUpdated = formatTime()
-	return nil
-}
+// Add your action methods here. Example:
+// func (s *CounterState) MyAction(ctx *livetemplate.ActionContext) error {
+//     // Handle action
+//     s.LastUpdated = formatTime()
+//     return nil
+// }
 
 func formatTime() string {
 	return time.Now().Format("2006-01-02 15:04:05")


### PR DESCRIPTION
## Summary

- Migrate all generator templates from `Store.Change()` switch-case pattern to automatic method dispatch
- Update all kit templates (simple, single, multi) to use the same pattern
- Migrate E2E tests to method dispatch
- Update golden files and README documentation

This aligns with the livetemplate core v0.6.0 changes that removed the `Store` interface in favor of method dispatch (PR #67).

## Changes

### Generator Templates
- `resource/handler.go.tmpl`: 13 actions converted to individual methods (Add, Edit, Update, CancelEdit, View, Back, Delete, Search, Sort, NextPage, PrevPage, GotoPage, LoadMore)
- `view/handler.go.tmpl`: Removed `Change()`, added comment with example method
- `app/home.go.tmpl`: Removed `Change()` (static page, no actions)

### Kit Templates
- **simple**: `main.go.tmpl` - Increment, Decrement, Reset methods
- **single**: All templates mirrored from generator
- **multi**: All templates mirrored from generator + auth handler

### Auth Handler
- `Register()`, `Login()`, `MagicLink()`, `ForgotPassword()`, `SwitchView()` methods

### E2E Tests
- `LoadingTestState`: Removed empty `Change()` method
- `FocusTestState`: Converted to `Increment()` method

## Test plan

- [x] Run `go test -v ./... -short` - all unit tests pass
- [x] Run focus/loading e2e tests - pass
- [x] Golden file tests updated and passing

## Breaking Change

Generated code will use method dispatch instead of `Change()` switch statements. Existing apps need to migrate manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)