### PR TITLE
chore: remove temporary livetemplate replace directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/livetemplate/lvt
 
 go 1.25
 
-require github.com/livetemplate/livetemplate v0.7.0
+require github.com/livetemplate/livetemplate v0.7.1
 
 require (
 	github.com/brianvoe/gofakeit/v7 v7.8.2
@@ -94,7 +94,3 @@ require (
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
 )
-
-// Use livetemplate branch with range statics fix (PR #72)
-// This will be removed once livetemplate v0.7.1+ is released
-replace github.com/livetemplate/livetemplate => github.com/livetemplate/livetemplate v0.7.1-0.20251212201619-6826d0962769

--- a/go.sum
+++ b/go.sum
@@ -146,8 +146,8 @@ github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kUL
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/livetemplate/livetemplate v0.7.1-0.20251212201619-6826d0962769 h1:3yEeah0uNpIApbEuS3Ybam+ii1rCfONiTEfe9YvdvTQ=
-github.com/livetemplate/livetemplate v0.7.1-0.20251212201619-6826d0962769/go.mod h1:mTI76skBGEx4jD9pO52L9xBY4/ZDW4muAKWwXnupvtc=
+github.com/livetemplate/livetemplate v0.7.1 h1:l9SB+TWZAB37Txn+PHCIPA6pOwRjT2EaxC3Uhka4UQA=
+github.com/livetemplate/livetemplate v0.7.1/go.mod h1:mTI76skBGEx4jD9pO52L9xBY4/ZDW4muAKWwXnupvtc=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=


### PR DESCRIPTION
## Summary
Remove the replace directive pointing to livetemplate PR #72 commit, now that the fix has been merged to livetemplate main.

The replace directive was added in PR #10 to enable cross-repo testing before the livetemplate fix was merged.

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)