### PR TITLE
fix: reinforce plan-first behavior in lvt-plan skill

### DIFF
--- a/commands/claude_resources/skills/plan/SKILL.md
+++ b/commands/claude_resources/skills/plan/SKILL.md
@@ -4,12 +4,43 @@ description: "Use when creating new LiveTemplate/lvt apps - this is THE definiti
 keywords: ["lvt", "livetemplate", "lt", "app", "application", "create", "build", "make", "new", "plan"]
 requires_keywords: true
 category: workflows
-version: 1.3.0
+version: 1.4.0
 ---
 
 # lvt-plan
 
 Plan-first skill for creating LiveTemplate applications. Presents a complete plan with sensible defaults upfront, lets user modify before execution.
+
+## CRITICAL: NO INDIVIDUAL QUESTIONS
+
+**DO NOT use AskUserQuestion tool with this skill.** Instead:
+1. Infer everything possible from the user's request
+2. Apply domain-specific defaults for anything not specified
+3. Present ONE complete plan with ALL settings filled in
+4. Let user say "yes" to proceed or "change X" to modify
+
+**WRONG** (asking questions one-by-one):
+```
+"What would you like to name your app?"
+"What type of authentication?"
+"How many records to seed?"
+```
+
+**RIGHT** (present complete plan immediately):
+```
+📋 Plan for your blog app
+
+| Setting | Value |
+|---------|-------|
+| App name | myblog |
+| Primary resource | posts (title:string, content:text, published:bool) |
+| Authentication | None |
+| Test data | 50 records |
+
+Ready to create? (yes/no/change X)
+```
+
+The user can then say "add auth" or "change name to techblog" to modify the plan.
 
 ## SKILL PRIORITY
 
@@ -90,7 +121,7 @@ Extract as much as possible from the initial prompt:
 | "make a **todo-app** using lt" | name=todo-app, domain=Todo |
 | "create a lvt app" | name=?, domain=? (need to ask) |
 
-**If domain is unclear**: Ask ONE question: "What type of app are you building? (blog, shop, todo, crm, or describe it)"
+**If domain is unclear**: Default to "Generic" domain and present the plan. User can say "it's a blog" to switch domains, or "change resource to posts" to customize.
 
 ---
 
@@ -347,6 +378,12 @@ After successful creation:
 ---
 
 ## Version History
+
+- **v1.4.0** (2025-12-20): Reinforce no-questions behavior
+  - Added CRITICAL section explicitly forbidding AskUserQuestion tool
+  - Added WRONG vs RIGHT examples at top of skill
+  - Changed "ask ONE question if unclear" to "default to Generic domain"
+  - Make plan-first approach more explicit
 
 - **v1.3.0** (2025-12-18): Plan-first approach
   - Present complete plan with defaults upfront


### PR DESCRIPTION
## Problem

The lvt-plan skill was being ignored - the AI was still asking questions one-by-one (name, auth type, seed count) instead of presenting a complete plan with sensible defaults.

## Solution

Added explicit instructions at the top of the skill:

1. **CRITICAL section** - Explicitly forbids using AskUserQuestion tool
2. **WRONG vs RIGHT examples** - Shows what NOT to do and what TO do
3. **Default to Generic domain** - Instead of asking "what type of app", just default to Generic and let user refine

## Expected Behavior

**Before** (wrong):
```
"What would you like to name your app?"
"What type of authentication?"
"How many records to seed?"
```

**After** (correct):
```
📋 Plan for your blog app

| Setting | Value |
|---------|-------|
| App name | myblog |
| Primary resource | posts (title, content, published) |
| Authentication | None |
| Test data | 50 records |

Ready to create? (yes/no/change X)
```

User can then say "add auth" or "100 records" to modify the plan.

## Test plan

- [x] Skill syntax is valid markdown
- [x] Version bumped to 1.4.0
- [x] Version history updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)