### PR TITLE
feat(auth): prompt to protect resources during auth generation

### DIFF
--- a/commands/auth.go
+++ b/commands/auth.go
@@ -155,13 +155,17 @@ func Auth(args []string) error {
 				if choice == "all" {
 					selectedResources = protectableResources
 				} else if choice != "none" && choice != "" {
-					// Parse comma-separated numbers
+					// Parse comma-separated numbers, preventing duplicates
 					parts := strings.Split(choice, ",")
+					seen := make(map[int]bool)
 					for _, part := range parts {
 						part = strings.TrimSpace(part)
 						if num, err := strconv.Atoi(part); err == nil {
 							if num >= 1 && num <= len(protectableResources) {
-								selectedResources = append(selectedResources, protectableResources[num-1])
+								if !seen[num] {
+									seen[num] = true
+									selectedResources = append(selectedResources, protectableResources[num-1])
+								}
 							} else {
 								fmt.Printf("⚠️  Invalid selection: %d (out of range)\n", num)
 							}


### PR DESCRIPTION
## Summary
- Adds interactive prompt after `lvt gen auth` to select which resources should be protected
- Wraps selected resource handlers with `authController.RequireAuth()` in main.go
- Adds authController creation if not already present

## Changes
- `commands/auth.go`: Add interactive prompt to select resources after auth generation
- `internal/generator/auth.go`: Add `ProtectResources()` function to update main.go
- `internal/generator/auth_test.go`: Add comprehensive tests for resource protection

## How it works
After auth generation completes, if there are existing resources (from `.lvtresources`), the CLI prompts:

```
🔒 Resource Protection
Would you like to protect any resources with authentication?
(Users will need to log in to access protected resources)

  1. Posts (/posts)
  2. Comments (/comments)

Enter your selection:
  - Numbers separated by commas (e.g., 1,2,3)
  - 'all' to protect all resources
  - 'none' to skip (you can protect resources later)

Your choice: all

Protecting 2 resource(s)...
✅ Resources protected!
   - Posts (/posts)
   - Comments (/comments)
```

## Test plan
- [x] Run `TestProtectResources_WrapsHandlers` - verifies handlers are wrapped
- [x] Run `TestProtectResources_Idempotent` - ensures no duplicates on re-run
- [x] Run `TestProtectResources_AddsAuthController` - verifies authController creation
- [x] Run `TestProtectResources_NoMainGo` - handles missing main.go gracefully
- [x] Manual test: Create app, add resources, run `lvt gen auth` with "all"

🤖 Generated with [Claude Code](https://claude.com/claude-code)