### PR TITLE
fix(resource): keep edit modal in DOM to prevent morphdom issues

### DIFF
--- a/internal/kits/system/multi/components/form.tmpl
+++ b/internal/kits/system/multi/components/form.tmpl
@@ -67,18 +67,18 @@
     <div[[if ne (fieldClass $.CSSFramework) ""]] class="[[fieldClass $.CSSFramework]]"[[end]]>
       <label[[if ne (labelClass $.CSSFramework) ""]] class="[[labelClass $.CSSFramework]]"[[end]]>[[.Name | title]]</label>
 [[- if .IsTextarea]]
-      <textarea[[if ne (inputClass $.CSSFramework) ""]] class="[[inputClass $.CSSFramework]]"[[end]] name="[[.Name]]" placeholder="Enter [[.Name]]" rows="5" required {{if .lvt.HasError "[[.Name]]"}}aria-invalid="true"{{end}}>{{.Editing[[$.ResourceName]].[[.Name | camelCase]]}}</textarea>
+      <textarea[[if ne (inputClass $.CSSFramework) ""]] class="[[inputClass $.CSSFramework]]"[[end]] name="[[.Name]]" placeholder="Enter [[.Name]]" rows="5" required {{if .lvt.HasError "[[.Name]]"}}aria-invalid="true"{{end}}>{{if .Editing[[$.ResourceName]]}}{{.Editing[[$.ResourceName]].[[.Name | camelCase]]}}{{end}}</textarea>
 [[- else if eq .GoType "string"]]
-      <input[[if ne (inputClass $.CSSFramework) ""]] class="[[inputClass $.CSSFramework]]"[[end]] type="text" name="[[.Name]]" placeholder="Enter [[.Name]]" value="{{.Editing[[$.ResourceName]].[[.Name | camelCase]]}}" required {{if .lvt.HasError "[[.Name]]"}}aria-invalid="true"{{end}}>
+      <input[[if ne (inputClass $.CSSFramework) ""]] class="[[inputClass $.CSSFramework]]"[[end]] type="text" name="[[.Name]]" placeholder="Enter [[.Name]]" value="{{if .Editing[[$.ResourceName]]}}{{.Editing[[$.ResourceName]].[[.Name | camelCase]]}}{{end}}" required {{if .lvt.HasError "[[.Name]]"}}aria-invalid="true"{{end}}>
 [[- else if eq .GoType "int64"]]
-      <input[[if ne (inputClass $.CSSFramework) ""]] class="[[inputClass $.CSSFramework]]"[[end]] type="number" name="[[.Name]]" placeholder="Enter [[.Name]]" value="{{.Editing[[$.ResourceName]].[[.Name | camelCase]]}}" required {{if .lvt.HasError "[[.Name]]"}}aria-invalid="true"{{end}}>
+      <input[[if ne (inputClass $.CSSFramework) ""]] class="[[inputClass $.CSSFramework]]"[[end]] type="number" name="[[.Name]]" placeholder="Enter [[.Name]]" value="{{if .Editing[[$.ResourceName]]}}{{.Editing[[$.ResourceName]].[[.Name | camelCase]]}}{{end}}" required {{if .lvt.HasError "[[.Name]]"}}aria-invalid="true"{{end}}>
 [[- else if eq .GoType "bool"]]
       <label[[if ne (checkboxClass $.CSSFramework) ""]] class="[[checkboxClass $.CSSFramework]]"[[end]]>
-        <input type="checkbox" name="[[.Name]]" value="true" {{if .Editing[[$.ResourceName]].[[.Name | camelCase]]}}checked{{end}} {{if .lvt.HasError "[[.Name]]"}}aria-invalid="true"{{end}}>
+        <input type="checkbox" name="[[.Name]]" value="true" {{if and .Editing[[$.ResourceName]] .Editing[[$.ResourceName]].[[.Name | camelCase]]}}checked{{end}} {{if .lvt.HasError "[[.Name]]"}}aria-invalid="true"{{end}}>
         [[.Name | title]]
       </label>
 [[- else if eq .GoType "float64"]]
-      <input[[if ne (inputClass $.CSSFramework) ""]] class="[[inputClass $.CSSFramework]]"[[end]] type="number" step="0.01" name="[[.Name]]" placeholder="Enter [[.Name]]" value="{{.Editing[[$.ResourceName]].[[.Name | camelCase]]}}" required {{if .lvt.HasError "[[.Name]]"}}aria-invalid="true"{{end}}>
+      <input[[if ne (inputClass $.CSSFramework) ""]] class="[[inputClass $.CSSFramework]]"[[end]] type="number" step="0.01" name="[[.Name]]" placeholder="Enter [[.Name]]" value="{{if .Editing[[$.ResourceName]]}}{{.Editing[[$.ResourceName]].[[.Name | camelCase]]}}{{end}}" required {{if .lvt.HasError "[[.Name]]"}}aria-invalid="true"{{end}}>
 [[- end]]
       {{if .lvt.HasError "[[.Name]]"}}
       <small style="color: #c00; font-size: 0.875rem;">{{.lvt.Error "[[.Name]]"}}</small>

--- a/internal/kits/system/multi/templates/resource/template_components.tmpl.tmpl
+++ b/internal/kits/system/multi/templates/resource/template_components.tmpl.tmpl
@@ -15,13 +15,11 @@
   {{template "addModal" .}}
 
   <!-- Edit Modal -->
-  {{if ne .EditingID ""}}
-  <div style="position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); display: flex; align-items: center; justify-content: center; z-index: 1000;">
+  <div id="edit-modal" {{if eq .EditingID ""}}hidden{{end}} style="position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); display: flex; align-items: center; justify-content: center; z-index: 1000;">
     <div style="background: white; border-radius: 8px; padding: 2rem; max-width: 600px; width: 90%; max-height: 90vh; overflow-y: auto;">
       {{template "editForm" .}}
     </div>
   </div>
-  {{end}}
 
   {{template "tableBox" .}}
 [[- end]]

--- a/testdata/golden/resource_template.tmpl.golden
+++ b/testdata/golden/resource_template.tmpl.golden
@@ -91,7 +91,7 @@
     <input type="hidden" name="id" value="{{.EditingID}}">
     <div class="mb-4">
       <label class="block text-sm font-medium text-gray-700 mb-2">Title</label>
-      <input class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500" type="text" name="title" placeholder="Enter title" value="{{.EditingPost.Title}}" required {{if .lvt.HasError "title"}}aria-invalid="true"{{end}}>
+      <input class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500" type="text" name="title" placeholder="Enter title" value="{{if .EditingPost}}{{.EditingPost.Title}}{{end}}" required {{if .lvt.HasError "title"}}aria-invalid="true"{{end}}>
       {{if .lvt.HasError "title"}}
       <small style="color: #c00; font-size: 0.875rem;">{{.lvt.Error "title"}}</small>
       {{end}}
@@ -99,7 +99,7 @@
     <div class="mb-4">
       <label class="block text-sm font-medium text-gray-700 mb-2">Published</label>
       <label class="flex items-center">
-        <input type="checkbox" name="published" value="true" {{if .EditingPost.Published}}checked{{end}} {{if .lvt.HasError "published"}}aria-invalid="true"{{end}}>
+        <input type="checkbox" name="published" value="true" {{if and .EditingPost .EditingPost.Published}}checked{{end}} {{if .lvt.HasError "published"}}aria-invalid="true"{{end}}>
         Published
       </label>
       {{if .lvt.HasError "published"}}
@@ -376,13 +376,11 @@
   {{template "addModal" .}}
 
   <!-- Edit Modal -->
-  {{if ne .EditingID ""}}
-  <div style="position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); display: flex; align-items: center; justify-content: center; z-index: 1000;">
+  <div id="edit-modal" {{if eq .EditingID ""}}hidden{{end}} style="position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); display: flex; align-items: center; justify-content: center; z-index: 1000;">
     <div style="background: white; border-radius: 8px; padding: 2rem; max-width: 600px; width: 90%; max-height: 90vh; overflow-y: auto;">
       {{template "editForm" .}}
     </div>
   </div>
-  {{end}}
 
   {{template "tableBox" .}}
 {{end}}


### PR DESCRIPTION
## Summary
- Edit modal was completely removed from DOM when `EditingID` was empty
- This caused morphdom diffing issues when reopening the modal (garbled output)
- Changed to use `hidden` attribute like `addModal` does
- Added nil checks for `EditingPosts` field access

## Test plan
- [x] Create a resource (post)
- [x] Click Edit to open modal
- [x] Click Save to close modal
- [x] Click Edit again - modal should reopen correctly (no garbled text)
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)