### PR TITLE
fix(e2e): use testURL for Chrome navigation instead of hardcoded localhost

### DIFF
--- a/e2e/complete_workflow_test.go
+++ b/e2e/complete_workflow_test.go
@@ -733,7 +733,7 @@ func TestCompleteWorkflow_BlogApp(t *testing.T) {
 		if tableRowCount > 0 {
 			t.Logf("[Delete_Post] Step 12c: Refreshing page to ensure DB state is reflected...")
 			chromedp.Run(ctx,
-				chromedp.Navigate("http://localhost:8800/posts"),
+				chromedp.Navigate(testURL+"/posts"),
 				waitFor(`document.querySelector('[data-lvt-id]') !== null`, 10*time.Second),
 			)
 		}


### PR DESCRIPTION
## Summary
- Fixed hardcoded `http://localhost:8800/posts` URL in complete_workflow_test.go
- Changed to use `testURL` which resolves to `host.docker.internal` for Docker-based Chrome

## Problem
When Chrome runs in a Docker container, `localhost` refers to the container itself, not the host machine where the test server is running. This caused e2e tests to fail with connection timeouts.

## Solution
The infrastructure for Docker host networking was already in place:
- `GetChromeTestURL()` returns `http://host.docker.internal:PORT`
- Docker containers are started with `--add-host host.docker.internal:host-gateway`
- `getTestURL()` wrapper function exists in e2e tests

The issue was one hardcoded URL that bypassed these helpers. This PR fixes that.

## Test plan
- [x] `TestModalFunctionality` passes
- [x] `TestRendering_Modal_Lifecycle` passes
- [x] All unit tests pass
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)