### PR TITLE
fix(generator): preserve loaded items when changing sort order

### DIFF
--- a/internal/generator/templates/resource/handler.go.tmpl
+++ b/internal/generator/templates/resource/handler.go.tmpl
@@ -296,10 +296,8 @@ func (c *[[.ResourceName]]Controller) Sort(state [[.ResourceName]]State, ctx *li
 		return state, err
 	}
 	state.SortBy = input.SortBy
-	// Reset infinite scroll when sorting
-	if state.PaginationMode == "infinite" || state.PaginationMode == "load-more" {
-		state.LoadedCount = state.PageSize
-	}
+	// Note: Don't reset LoadedCount when sorting - keep all loaded items visible
+	// Just re-sort the existing items for better UX
 
 	state, err := c.load[[.ResourceName]]s(state, dbCtx)
 	if err != nil {

--- a/internal/kits/system/multi/templates/resource/handler.go.tmpl
+++ b/internal/kits/system/multi/templates/resource/handler.go.tmpl
@@ -288,10 +288,8 @@ func (c *[[.ResourceName]]Controller) Sort(state [[.ResourceName]]State, ctx *li
 		return state, err
 	}
 	state.SortBy = input.SortBy
-	// Reset infinite scroll when sorting
-	if state.PaginationMode == "infinite" || state.PaginationMode == "load-more" {
-		state.LoadedCount = state.PageSize
-	}
+	// Note: Don't reset LoadedCount when sorting - keep all loaded items visible
+	// Just re-sort the existing items for better UX
 
 	state, err := c.load[[.ResourceName]]s(state, dbCtx)
 	if err != nil {

--- a/internal/kits/system/single/templates/resource/handler.go.tmpl
+++ b/internal/kits/system/single/templates/resource/handler.go.tmpl
@@ -296,10 +296,8 @@ func (c *[[.ResourceName]]Controller) Sort(state [[.ResourceName]]State, ctx *li
 		return state, err
 	}
 	state.SortBy = input.SortBy
-	// Reset infinite scroll when sorting
-	if state.PaginationMode == "infinite" || state.PaginationMode == "load-more" {
-		state.LoadedCount = state.PageSize
-	}
+	// Note: Don't reset LoadedCount when sorting - keep all loaded items visible
+	// Just re-sort the existing items for better UX
 
 	state, err := c.load[[.ResourceName]]s(state, dbCtx)
 	if err != nil {

--- a/testdata/golden/resource_handler.go.golden
+++ b/testdata/golden/resource_handler.go.golden
@@ -272,10 +272,8 @@ func (c *UserController) Sort(state UserState, ctx *livetemplate.Context) (UserS
 		return state, err
 	}
 	state.SortBy = input.SortBy
-	// Reset infinite scroll when sorting
-	if state.PaginationMode == "infinite" || state.PaginationMode == "load-more" {
-		state.LoadedCount = state.PageSize
-	}
+	// Note: Don't reset LoadedCount when sorting - keep all loaded items visible
+	// Just re-sort the existing items for better UX
 
 	state, err := c.loadUsers(state, dbCtx)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Fix sort handler to preserve `LoadedCount` when changing sort order
- Items are re-sorted in place rather than resetting to first page
- Applies to all kits: multi, single, and generator templates

## Problem

When using infinite scroll pagination and changing the sort order (e.g., "Oldest first" to "Newest first"), the `LoadedCount` was being reset to `PageSize` (20). This made it appear that posts were "missing" when they were actually just paginated away.

**Before:**
1. Load page → 20 posts shown
2. Scroll down → 40 posts loaded
3. Change sort → **Only 20 posts shown** (feels like posts disappeared!)

**After:**
1. Load page → 20 posts shown
2. Scroll down → 40 posts loaded
3. Change sort → **40 posts still shown** (just re-sorted)

## Code Change

```go
// Before:
state.SortBy = input.SortBy
// Reset infinite scroll when sorting
if state.PaginationMode == "infinite" || state.PaginationMode == "load-more" {
    state.LoadedCount = state.PageSize  // ← This reset caused the bug
}

// After:
state.SortBy = input.SortBy
// Note: Don't reset LoadedCount when sorting - keep all loaded items visible
// Just re-sort the existing items for better UX
```

## Design Decision

- **Sort**: Keep all loaded items visible, just re-sort them (this PR)
- **Search**: Still resets to first page (intentional - search changes the dataset)

## Test plan

- [x] Unit tests pass (`make test-fast`)
- [ ] Manual test: Change sort order with loaded items - items stay visible
- [ ] Verify search still resets pagination (intentional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)