### PR TITLE
fix(testing): remove SKIP_GO_MOD_TIDY from agent tests

### DIFF
--- a/commands/new.go
+++ b/commands/new.go
@@ -84,35 +84,27 @@ func New(args []string) error {
 
 	fmt.Println()
 
-	// Skip go mod tidy when running under test to avoid "Test I/O incomplete" errors
-	// Tests handle go mod tidy separately with proper synchronization
-	if os.Getenv("SKIP_GO_MOD_TIDY") != "1" {
-		// Run go mod tidy to resolve and download dependencies
-		fmt.Println("Installing dependencies...")
-		cmd := exec.Command("go", "mod", "tidy")
-		cmd.Dir = appName
-		// Disable workspace mode to prevent background processes
-		cmd.Env = append(os.Environ(), "GOWORK=off")
+	// Run go mod tidy to resolve and download dependencies
+	fmt.Println("Installing dependencies...")
+	cmd := exec.Command("go", "mod", "tidy")
+	cmd.Dir = appName
+	// Disable workspace mode to prevent background processes
+	cmd.Env = append(os.Environ(), "GOWORK=off")
 
-		// Use CombinedOutput() instead of Run() to properly close pipes
-		// This prevents "Test I/O incomplete" errors when running under test frameworks
-		// Note: CombinedOutput captures stdout/stderr internally, so we don't set cmd.Stdout/Stderr
-		output, err := cmd.CombinedOutput()
-		if err != nil {
-			fmt.Printf("⚠️  Warning: failed to install dependencies: %v\n", err)
-			if len(output) > 0 {
-				fmt.Printf("   Output: %s\n", string(output))
-			}
-			fmt.Printf("   You can run it manually: cd %s && go mod tidy\n", appName)
-		} else {
-			// Print output if there was any (warnings, etc.)
-			if len(output) > 0 {
-				fmt.Print(string(output))
-			}
-			fmt.Println("✅ Dependencies installed!")
+	// Use CombinedOutput() to capture stdout/stderr and properly close pipes
+	// This prevents "Test I/O incomplete" errors when running under test frameworks
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Printf("⚠️  Warning: failed to install dependencies: %v\n", err)
+		if len(output) > 0 {
+			fmt.Printf("   Output: %s\n", string(output))
 		}
+		fmt.Printf("   You can run it manually: cd %s && go mod tidy\n", appName)
 	} else {
-		fmt.Println("⏭️  Skipping dependency installation (test mode)")
+		if len(output) > 0 {
+			fmt.Print(string(output))
+		}
+		fmt.Println("✅ Dependencies installed!")
 	}
 
 	fmt.Println()

--- a/e2e/AGENT_TESTING_README.md
+++ b/e2e/AGENT_TESTING_README.md
@@ -58,7 +58,7 @@ Each test verifies:
 
 Tests run in complete isolation:
 - Each test gets a fresh temp directory
-- Apps are created with `SKIP_GO_MOD_TIDY=1` for speed
+- Apps run `go mod tidy` during creation (same as real usage)
 - No shared state between tests
 - Automatic cleanup
 
@@ -178,7 +178,7 @@ go test -v -run TestMCPTool ./commands
 go test -v -run TestMCPTool_LvtNew ./commands
 
 # Run with short mode (skips long-running tests)
-SKIP_GO_MOD_TIDY=1 go test -short -run TestMCPTool ./commands
+go test -short -run TestMCPTool ./commands
 ```
 
 ### What MCP Tests Validate
@@ -194,7 +194,7 @@ Each tool test verifies:
 
 MCP tests use isolated environments:
 - Each test gets a fresh temp directory
-- Apps are created with `SKIP_GO_MOD_TIDY=1` for speed
+- Apps run `go mod tidy` during creation (same as real usage)
 - Tests clean up automatically
 - No shared state between tests
 

--- a/internal/agenttest/harness.go
+++ b/internal/agenttest/harness.go
@@ -60,19 +60,11 @@ func Setup(t *testing.T, opts *SetupOptions) *AgentTestEnv {
 		err = os.Chdir(tmpDir)
 		require.NoError(t, err)
 
-		// Create app with SKIP_GO_MOD_TIDY to avoid test I/O issues
-		os.Setenv("SKIP_GO_MOD_TIDY", "1")
-		defer os.Unsetenv("SKIP_GO_MOD_TIDY")
-
 		args := []string{opts.AppName, "--kit", opts.Kit}
 		err = commands.New(args)
 		require.NoError(t, err, "failed to create test app")
 
 		appDir = filepath.Join(tmpDir, opts.AppName)
-
-		// Run go mod tidy separately with proper synchronization
-		err = runGoModTidy(t, appDir)
-		require.NoError(t, err, "failed to run go mod tidy")
 
 		// Return to original directory
 		err = os.Chdir(originalDir)
@@ -293,12 +285,4 @@ func (e *AgentTestEnv) SimulateConversation(steps []ConversationStep) {
 type ConversationStep struct {
 	Prompt  string
 	Execute func(*AgentTestEnv)
-}
-
-// runGoModTidy runs go mod tidy in the specified directory
-func runGoModTidy(t *testing.T, dir string) error {
-	t.Helper()
-	// For now, we skip this as it's handled by SKIP_GO_MOD_TIDY flag
-	// and the test infrastructure
-	return nil
 }


### PR DESCRIPTION
## Summary

- Removed `SKIP_GO_MOD_TIDY` environment variable from `commands/new.go` — `go mod tidy` now always runs during app creation
- Removed env var setting and no-op `runGoModTidy` function from `internal/agenttest/harness.go`
- Updated `e2e/AGENT_TESTING_README.md` to reflect that tests now run `go mod tidy` (matching real-world behavior)

## Test plan

- [x] All agent doc validation tests pass (`TestAgentDocValidation_*` — 7 tests)
- [x] All kit variants tested (multi, single, simple)
- [x] MCP tool tests pass (`TestMCPTool_LvtNew`)
- [x] Full `go test ./...` passes across all packages
- [x] Zero `SKIP_GO_MOD_TIDY` references remaining in Go source files

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)