### PR TITLE
fix: compare EditingID to empty string instead of integer 0

### DIFF
--- a/internal/generator/templates/resource/template.tmpl.tmpl
+++ b/internal/generator/templates/resource/template.tmpl.tmpl
@@ -112,7 +112,7 @@
       {{end}}
 
       <!-- Edit Modal -->
-      {{if ne .EditingID 0}}
+      {{if ne .EditingID ""}}
       <div style="position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); display: flex; align-items: center; justify-content: center; z-index: 1000;">
 [[- if needsArticle .CSSFramework]]
         <article style="max-width: 600px; width: 90%; max-height: 90vh; overflow-y: auto;">

--- a/internal/kits/system/multi/templates/resource/template.tmpl.tmpl
+++ b/internal/kits/system/multi/templates/resource/template.tmpl.tmpl
@@ -116,7 +116,7 @@
       </div>
 
       <!-- Edit Modal -->
-      {{if ne .EditingID 0}}
+      {{if ne .EditingID ""}}
       <div style="position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); display: flex; align-items: center; justify-content: center; z-index: 1000;">
 [[- if needsArticle .CSSFramework]]
         <article style="max-width: 600px; width: 90%; max-height: 90vh; overflow-y: auto;">


### PR DESCRIPTION
## Summary

- Fix `{{if ne .EditingID 0}}` → `{{if ne .EditingID ""}}` in the **generator** template (`internal/generator/templates/resource/template.tmpl.tmpl`)
- Fix the same comparison in the **multi kit** template (`internal/kits/system/multi/templates/resource/template.tmpl.tmpl`)
- `EditingID` is declared as `string` in handler structs, so comparing to integer `0` causes a Go template type error at render time. The single kit was already fixed in `5700a82`.

## Test plan

- [x] `GOWORK=off go test ./... -short` — all pass (golden file tests validate the fix)
- [x] `GOWORK=off go vet ./...` — clean
- [x] `grep -r 'EditingID 0' internal/` — zero matches

Fixes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)