### PR TITLE
feat(generator): add template parse validation after generation

### DIFF
--- a/internal/generator/resource.go
+++ b/internal/generator/resource.go
@@ -175,9 +175,13 @@ func GenerateResource(basePath, moduleName, resourceName string, fields []parser
 		return fmt.Errorf("failed to generate handler: %w", err)
 	}
 
-	// Generate template
-	if err := generateFile(string(templateTmpl), data, filepath.Join(resourceDir, resourceNameLower+".tmpl"), kit); err != nil {
+	// Generate template and validate it parses correctly
+	tmplPath := filepath.Join(resourceDir, resourceNameLower+".tmpl")
+	if err := generateFile(string(templateTmpl), data, tmplPath, kit); err != nil {
 		return fmt.Errorf("failed to generate template: %w", err)
+	}
+	if err := ValidateTemplate(tmplPath); err != nil {
+		return err
 	}
 
 	// Generate migration file instead of appending to schema.sql

--- a/internal/generator/validate.go
+++ b/internal/generator/validate.go
@@ -1,0 +1,77 @@
+package generator
+
+import (
+	"fmt"
+	"html/template"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// lineNumberPattern matches Go template parse error positions like "template: name:5:" or "template: name:5:22:"
+var lineNumberPattern = regexp.MustCompile(`template:.*?:(\d+)`)
+
+// ValidateTemplate parses a generated .tmpl file and returns a clear error
+// if the template contains syntax errors. This catches issues at generation
+// time rather than at runtime.
+func ValidateTemplate(path string) error {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read template %s: %w", path, err)
+	}
+
+	_, err = template.New(filepath.Base(path)).Parse(string(content))
+	if err != nil {
+		return formatTemplateError(path, string(content), err)
+	}
+	return nil
+}
+
+// formatTemplateError enhances a template parse error with file path,
+// line number, and surrounding source context.
+func formatTemplateError(path, content string, parseErr error) error {
+	lineNum := extractLineNumber(parseErr)
+	if lineNum <= 0 {
+		return fmt.Errorf("template syntax error in %s: %w", path, parseErr)
+	}
+
+	context := sourceContext(content, lineNum, 2)
+	return fmt.Errorf("template syntax error in %s (line %d):\n%s\n  error: %w", path, lineNum, context, parseErr)
+}
+
+// extractLineNumber pulls the line number from a Go template parse error message.
+func extractLineNumber(err error) int {
+	matches := lineNumberPattern.FindStringSubmatch(err.Error())
+	if len(matches) < 2 {
+		return 0
+	}
+	n, convErr := strconv.Atoi(matches[1])
+	if convErr != nil {
+		return 0
+	}
+	return n
+}
+
+// sourceContext returns a few lines of source around the given line number,
+// with line numbers and an arrow marking the error line.
+func sourceContext(content string, lineNum, surroundingLines int) string {
+	lines := strings.Split(content, "\n")
+	if lineNum < 1 || lineNum > len(lines) {
+		return ""
+	}
+
+	start := max(lineNum-surroundingLines-1, 0)
+	end := min(lineNum+surroundingLines, len(lines))
+
+	var b strings.Builder
+	for i := start; i < end; i++ {
+		marker := "  "
+		if i+1 == lineNum {
+			marker = "→ "
+		}
+		fmt.Fprintf(&b, "  %s%4d | %s\n", marker, i+1, lines[i])
+	}
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/internal/generator/validate_test.go
+++ b/internal/generator/validate_test.go
@@ -1,0 +1,190 @@
+package generator
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateTemplate_ValidTemplate(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "valid.tmpl")
+
+	content := `{{define "layout"}}
+<!DOCTYPE html>
+<html>
+<head><title>{{.Title}}</title></head>
+<body>
+  {{block "content" .}}{{end}}
+</body>
+</html>
+{{end}}`
+
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ValidateTemplate(path); err != nil {
+		t.Errorf("expected valid template, got error: %v", err)
+	}
+}
+
+func TestValidateTemplate_InvalidSyntax(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "invalid.tmpl")
+
+	content := `{{define "layout"}}
+<html>
+<body>
+  {{if .Show}
+  <p>Hello</p>
+  {{end}}
+</body>
+</html>
+{{end}}`
+
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := ValidateTemplate(path)
+	if err == nil {
+		t.Fatal("expected error for invalid template, got nil")
+	}
+
+	errMsg := err.Error()
+
+	// Should include file path
+	if !strings.Contains(errMsg, path) {
+		t.Errorf("error should include file path %q, got: %s", path, errMsg)
+	}
+
+	// Should include line number
+	if !strings.Contains(errMsg, "line") {
+		t.Errorf("error should include line number, got: %s", errMsg)
+	}
+
+	// Should include source context with arrow marker
+	if !strings.Contains(errMsg, "→") {
+		t.Errorf("error should include source context arrow, got: %s", errMsg)
+	}
+}
+
+func TestValidateTemplate_FileNotFound(t *testing.T) {
+	err := ValidateTemplate("/nonexistent/path/template.tmpl")
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to read template") {
+		t.Errorf("expected read error, got: %v", err)
+	}
+}
+
+func TestValidateTemplate_EmptyTemplate(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.tmpl")
+
+	if err := os.WriteFile(path, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ValidateTemplate(path); err != nil {
+		t.Errorf("empty template should be valid, got error: %v", err)
+	}
+}
+
+func TestValidateTemplate_UnclosedAction(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "unclosed.tmpl")
+
+	content := `<html>
+<body>
+  {{range .Items
+</body>
+</html>`
+
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := ValidateTemplate(path)
+	if err == nil {
+		t.Fatal("expected error for unclosed action")
+	}
+	if !strings.Contains(err.Error(), path) {
+		t.Errorf("error should include file path, got: %v", err)
+	}
+}
+
+func TestExtractLineNumber(t *testing.T) {
+	tests := []struct {
+		name     string
+		errMsg   string
+		expected int
+	}{
+		{"standard error", "template: test.tmpl:5: unexpected", 5},
+		{"with column", "template: test.tmpl:12:22: function not defined", 12},
+		{"no line number", "some other error", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractLineNumber(fmt.Errorf("%s", tt.errMsg))
+			if got != tt.expected {
+				t.Errorf("extractLineNumber(%q) = %d, want %d", tt.errMsg, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSourceContext(t *testing.T) {
+	content := "line1\nline2\nline3\nline4\nline5\nline6\nline7"
+
+	ctx := sourceContext(content, 4, 2)
+
+	// Should include lines 2-6 (4 ± 2)
+	if !strings.Contains(ctx, "line2") {
+		t.Error("context should include line 2")
+	}
+	if !strings.Contains(ctx, "line6") {
+		t.Error("context should include line 6")
+	}
+	// Line 4 should be marked with arrow
+	if !strings.Contains(ctx, "→") {
+		t.Error("context should mark error line with →")
+	}
+	// Should show line numbers
+	if !strings.Contains(ctx, "4 |") {
+		t.Error("context should show line numbers")
+	}
+}
+
+func TestSourceContext_FirstLine(t *testing.T) {
+	content := "line1\nline2\nline3"
+
+	ctx := sourceContext(content, 1, 2)
+
+	// Should include lines 1-3
+	if !strings.Contains(ctx, "line1") {
+		t.Error("context should include line 1")
+	}
+	if !strings.Contains(ctx, "→") {
+		t.Error("context should mark error line")
+	}
+}
+
+func TestSourceContext_OutOfRange(t *testing.T) {
+	content := "line1\nline2"
+
+	ctx := sourceContext(content, 10, 2)
+	if ctx != "" {
+		t.Errorf("out of range should return empty, got: %s", ctx)
+	}
+
+	ctx = sourceContext(content, 0, 2)
+	if ctx != "" {
+		t.Errorf("zero line should return empty, got: %s", ctx)
+	}
+}

--- a/internal/generator/view.go
+++ b/internal/generator/view.go
@@ -80,9 +80,13 @@ func GenerateView(basePath, moduleName, viewName string, kitName, cssFramework s
 		return fmt.Errorf("failed to generate handler: %w", err)
 	}
 
-	// Generate template
-	if err := generateFile(string(templateTmpl), data, filepath.Join(viewDir, viewNameLower+".tmpl"), kit); err != nil {
+	// Generate template and validate it parses correctly
+	tmplPath := filepath.Join(viewDir, viewNameLower+".tmpl")
+	if err := generateFile(string(templateTmpl), data, tmplPath, kit); err != nil {
 		return fmt.Errorf("failed to generate template: %w", err)
+	}
+	if err := ValidateTemplate(tmplPath); err != nil {
+		return err
 	}
 
 	// Generate consolidated test file (E2E + WebSocket)


### PR DESCRIPTION
## Summary

- Add `ValidateTemplate()` function that parses generated `.tmpl` files with `html/template` immediately after writing them, catching syntax errors at generation time instead of runtime
- Error messages include file path, line number, and surrounding source context with an arrow marker (`→`) for quick identification
- Validation is called in both `GenerateResource()` and `GenerateView()` after the `.tmpl` file is written

Closes #55

## Test plan

- [x] Unit tests for `ValidateTemplate` (valid, invalid syntax, missing file, empty, unclosed actions)
- [x] Unit tests for `extractLineNumber` (standard errors, column errors, no line number)
- [x] Unit tests for `sourceContext` (middle, first line, out of range)
- [x] Existing golden tests pass (validates generated templates parse correctly)
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)