### PR TITLE
Add pull request trigger to deployment tests workflow

### DIFF
--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -1,6 +1,13 @@
 name: Deployment Tests
 
 on:
+  # Run mock tests on PRs to validate deployment infrastructure
+  pull_request:
+    paths:
+      - 'internal/deploy/**'
+      - 'e2e/**'
+      - '.github/workflows/deployment-tests.yml'
+
   # Allow manual triggering
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary
Updated the deployment tests GitHub Actions workflow to automatically run on pull requests that modify deployment-related code, in addition to manual triggering.

## Key Changes
- Added `pull_request` trigger to the workflow with path filtering
- Configured the workflow to run when changes are made to:
  - `internal/deploy/**` - deployment infrastructure code
  - `e2e/**` - end-to-end tests
  - `.github/workflows/deployment-tests.yml` - the workflow file itself
- Preserved existing `workflow_dispatch` manual trigger capability

## Details
This change enables continuous validation of deployment infrastructure by automatically running mock tests whenever relevant code is modified in a pull request. The path-based filtering ensures the workflow only runs when necessary, avoiding unnecessary CI overhead for unrelated changes.

https://claude.ai/code/session_01NkKNvLdDz2DZG7dMEANEEQ