### PR TITLE
test(e2e): extend wire format tests (#96)

### DIFF
--- a/e2e/wire_format_test.go
+++ b/e2e/wire_format_test.go
@@ -711,6 +711,7 @@ func TestWireFormat(t *testing.T) {
 	})
 
 	// --- Subtest 8: Structure change resends statics ---
+	// NOTE: Depends on Subtest 7 leaving Visible=false.
 	t.Run("8_Structure_Change_Resends_Statics", func(t *testing.T) {
 		// After subtest 7, Visible is false (conditional hidden).
 		// Toggling back to true changes the tree structure: the conditional
@@ -797,6 +798,9 @@ func TestWireFormat(t *testing.T) {
 		treeMsgs := getReceivedMessagesWithTree(wsLogger)
 		if len(treeMsgs) == 0 {
 			t.Fatal("No tree messages to validate")
+		}
+		if len(treeMsgs) < 8 {
+			t.Errorf("Expected at least 8 tree messages (initial + 7 actions), got %d", len(treeMsgs))
 		}
 
 		for i, msg := range treeMsgs {


### PR DESCRIPTION
## Summary
- Adds 3 new subtests and `findMetadata()` helper to `wire_format_test.go`
- **Subtest 8 (Structure_Change_Resends_Statics)**: Validates the core PR #86 fingerprint behavior — when a conditional reappears (false→true), tree structure changes and statics must be resent
- **Subtest 9 (Range_Metadata_IDKey)**: Validates the `"m": {"idKey": "..."}` metadata is present in initial render for range nodes
- **Subtest 10 (Envelope_Schema_Validation)**: Validates `UpdateResponse` envelope schema (meta.success, meta.action, meta.errors) across all captured messages

Closes livetemplate/livetemplate#96

## Test plan
- [x] All 10 wire format subtests pass locally
- [x] New subtests follow existing patterns (chromedp + WebSocket capture)
- [x] No changes to existing subtests

🤖 Generated with [Claude Code](https://claude.com/claude-code)