### PR TITLE
chore: upgrade Go to 1.26

### DIFF
--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -55,7 +55,7 @@ LiveTemplate apps are standard Go binaries with SQLite databases, making them ea
 
 ```dockerfile
 # Build stage
-FROM golang:1.23-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /app
 

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
 
       - name: Install dependencies

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,5 +1,5 @@
 # Dockerfile for running deployment tests in a container
-FROM golang:1.23-alpine
+FROM golang:1.26-alpine
 
 # Install Docker CLI and other dependencies
 RUN apk add --no-cache \

--- a/commands/claude_resources/skills/deploy/SKILL.md
+++ b/commands/claude_resources/skills/deploy/SKILL.md
@@ -55,7 +55,7 @@ LiveTemplate apps are standard Go binaries with SQLite databases, making them ea
 
 ```dockerfile
 # Build stage
-FROM golang:1.23-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /app
 

--- a/e2e/Dockerfile.base
+++ b/e2e/Dockerfile.base
@@ -1,5 +1,5 @@
 # Base image with all common dependencies for lvt-generated apps
-FROM golang:1.25-alpine AS base
+FROM golang:1.26-alpine AS base
 
 # Install build dependencies for CGO (SQLite)
 RUN apk add --no-cache gcc musl-dev sqlite-dev

--- a/e2e/docker_helpers_test.go
+++ b/e2e/docker_helpers_test.go
@@ -244,7 +244,7 @@ func ensureDockerfile(t *testing.T, appDir string) {
 
 	// Use the multi-stage Dockerfile pattern from testing/deployment.go
 	dockerfile := `# Build stage
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /app
 

--- a/e2e/shared_test.go
+++ b/e2e/shared_test.go
@@ -123,7 +123,7 @@ func setupSharedResources() error {
 			"-v", fmt.Sprintf("%s:/app", appDir),
 			"-w", "/app",
 			"-e", "GOWORK=off",
-			"golang:1.25",
+			"golang:1.26",
 			"sh", "-c", "go mod tidy && go mod vendor")
 
 		dockerOutput, err := dockerCmd.CombinedOutput()
@@ -139,7 +139,7 @@ func setupSharedResources() error {
 			"-v", fmt.Sprintf("%s:/app", appDir),
 			"-w", "/app",
 			"-e", "GOWORK=off",
-			"golang:1.25",
+			"golang:1.26",
 			"go", "run", "github.com/sqlc-dev/sqlc/cmd/sqlc@latest", "generate", "-f", "database/sqlc.yaml")
 
 		sqlcOutput, err := sqlcDockerCmd.CombinedOutput()

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/livetemplate/lvt
 
-go 1.25
+go 1.26.0
 
 require github.com/livetemplate/livetemplate v0.8.2
 

--- a/internal/stack/digitalocean/templates/Dockerfile.tmpl
+++ b/internal/stack/digitalocean/templates/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /app
 

--- a/internal/stack/docker/templates/Dockerfile.tmpl
+++ b/internal/stack/docker/templates/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /app
 

--- a/internal/stack/fly/templates/Dockerfile.tmpl
+++ b/internal/stack/fly/templates/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /app
 

--- a/testing/deployment.go
+++ b/testing/deployment.go
@@ -545,7 +545,7 @@ func (dt *DeploymentTest) ensureDockerfile() error {
 	// Create a minimal Dockerfile for testing
 	// Supports both simple kit (main.go in root) and multi kit (main.go in cmd/<appname>/)
 	dockerfile := `# Build stage
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Upgrade Go to 1.26.0 in go.mod
- Update CI workflow Go versions to 1.26 (test.yml, deployment-tests.yml)
- Update Dockerfile base images to golang:1.26-alpine (Dockerfile.test, e2e/Dockerfile.base, all stack templates)
- Update Go version references in test helpers and skill docs

## Test plan
- [x] `go mod tidy` completes without errors
- [x] `go test ./...` passes (unit tests, skipping e2e/Docker tests which need CI environment)
- [x] `go build ./...` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)