### PR TITLE
fix(ci): remove invalid secrets reference from workflow

### DIFF
--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -64,11 +64,16 @@ jobs:
           go test -v ./e2e -run TestDockerDeployment -timeout=10m
 
       - name: Run Fly.io Deployment Tests
-        if: ${{ github.event.inputs.run_fly_tests == 'true' && secrets.FLY_API_TOKEN != '' }}
+        if: ${{ github.event.inputs.run_fly_tests == 'true' }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
           RUN_FLY_DEPLOYMENT_TESTS: 'true'
         run: |
+          if [ -z "$FLY_API_TOKEN" ]; then
+            echo "FLY_API_TOKEN not set, skipping Fly.io tests"
+            exit 0
+          fi
+
           # Install flyctl
           curl -L https://fly.io/install.sh | sh
           export FLYCTL_INSTALL="/home/runner/.fly"


### PR DESCRIPTION
## Summary

- Remove `secrets.FLY_API_TOKEN != ''` from step-level `if:` expression where the `secrets` context is not available, causing the entire workflow to be rejected as invalid YAML
- Move the secret-presence check into the step's `run:` script, where it's accessed via `$FLY_API_TOKEN` from the `env:` mapping (which is a valid use of `secrets`)

## Test plan

- [ ] Workflow file passes GitHub's syntax validation (no more "Invalid workflow file" errors)
- [ ] Push events that don't touch deployment files skip cleanly
- [ ] Manual workflow_dispatch with `run_fly_tests=true` but no `FLY_API_TOKEN` secret prints skip message and exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)