### PR TITLE
fix: data race in RuntimeCheck.Run reading appOut before cmd.Wait

### DIFF
--- a/internal/validation/runtime.go
+++ b/internal/validation/runtime.go
@@ -93,27 +93,36 @@ func (c *RuntimeCheck) Run(ctx context.Context, appPath string) *validator.Valid
 	procDone := make(chan error, 1)
 	go func() { procDone <- cmd.Wait() }()
 
-	// Track whether procDone was already consumed (by waitForReadyOrExit
-	// detecting early exit). Without this, the deferred cleanup would
-	// deadlock trying to receive from an already-drained channel.
-	procConsumed := false
-
-	// Ensure process cleanup — kill + wait to avoid zombies.
-	defer func() {
+	// stopProcess kills the subprocess and waits for cmd.Wait() to finish.
+	// This must be called before reading appOut because os/exec spawns an
+	// internal goroutine that copies subprocess pipes into appOut; that
+	// goroutine only stops when cmd.Wait() returns.
+	procStopped := false
+	stopProcess := func() {
+		if procStopped {
+			return
+		}
+		procStopped = true
 		appCancel()
 		_ = cmd.Process.Kill()
-		if !procConsumed {
-			<-procDone
-		}
-	}()
+		<-procDone
+	}
+	defer stopProcess()
 
 	// 4. Wait for the app to be ready, or detect early process exit.
 	baseURL := fmt.Sprintf("http://localhost:%d", port)
 	ready, earlyExit := waitForReadyOrExit(ctx, baseURL, timeout, procDone)
-	if earlyExit {
-		procConsumed = true
-	}
 	if !ready {
+		// Stop process before reading appOut to avoid data race with
+		// the os/exec pipe copier goroutine.
+		if !earlyExit {
+			stopProcess()
+		} else {
+			// Process already exited and cmd.Wait() already returned
+			// (consumed by waitForReadyOrExit), so pipes are closed.
+			procStopped = true
+		}
+
 		var msg string
 		switch {
 		case ctx.Err() != nil:


### PR DESCRIPTION
## Summary

- Fix data race in `RuntimeCheck.Run()` that causes `TestRuntimeCheck_StartupTimeout` to fail under `-race` on every CI run since PR #121
- The race: `appOut.Bytes()` was read to build error messages while `os/exec`'s internal pipe copier goroutine was still writing to `appOut`
- The fix: extract process cleanup into `stopProcess()` and call it before reading `appOut`, ensuring `cmd.Wait()` has returned and the pipe copier has finished

This race was introduced in #121 (Milestone 2 — Validation Layer) and breaks the Cross-Repository Tests workflow in the core `livetemplate/livetemplate` repo on every PR.

## Test plan

- [x] `TestRuntimeCheck_StartupTimeout` passes with `-race` (5/5 consecutive runs)
- [x] All `TestRuntimeCheck_*` tests pass with `-race`
- [x] Full `go test -race ./...` passes across all lvt packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)