### PR TITLE
ci: skip heavy workflows for docs-only changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,10 @@ name: Test
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'LICENSE'
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- Add `paths-ignore` for `docs/**`, `**/*.md`, and `LICENSE` to the `test.yml` workflow
- Bot reviewer workflows (`claude-code-review.yml`, `claude.yml`) are intentionally unchanged
- `components-independence.yml` and `deployment-tests.yml` already have `paths:` filters so no changes needed

## Test plan
- [x] Verify `paths-ignore` patterns are present in `test.yml`
- [x] Verify bot reviewer workflows are not modified
- [x] All tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)