### PR TITLE
fix: eliminate data race on os.Stderr in parallel e2e tests

### DIFF
--- a/e2e/template_edge_cases_test.go
+++ b/e2e/template_edge_cases_test.go
@@ -114,8 +114,17 @@ func verifyAppBuildsAndRuns(t *testing.T, appDir string, hasQueries bool) {
 		fmt.Sprintf("PORT=%d", port),
 		"TEST_MODE=1",
 	)
-	serverCmd.Stdout = os.Stderr
-	serverCmd.Stderr = os.Stderr
+
+	// Write server output to a log file to avoid data races on os.Stderr
+	// (runLvtCommandWithOutput temporarily redirects os.Stderr in parallel tests)
+	serverLogPath := filepath.Join(appDir, "server.log")
+	serverLog, err := os.Create(serverLogPath)
+	if err != nil {
+		t.Fatalf("Failed to create server log file: %v", err)
+	}
+	t.Cleanup(func() { serverLog.Close() })
+	serverCmd.Stdout = serverLog
+	serverCmd.Stderr = serverLog
 
 	if err := serverCmd.Start(); err != nil {
 		t.Fatalf("Failed to start server: %v", err)


### PR DESCRIPTION
## Summary
- `verifyAppBuildsAndRuns` was writing server output directly to `os.Stderr`, which races with `runLvtCommandWithOutput` temporarily redirecting `os.Stderr` in parallel tests
- Replaced with per-app log files to eliminate the race detected by `-race` flag
- Fixes `TestTemplateEdgeCases/ResourceNoAuth` and `TestTemplateEdgeCases/AuthNoResources` data race failures

## Test plan
- [ ] CI passes with `-race` flag enabled
- [ ] `TestTemplateEdgeCases` subtests all pass in parallel

🤖 Generated with [Claude Code](https://claude.com/claude-code)