### PR TITLE
feat: add caching layer with memory and SQLite backends (Roadmap 3.1)

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,0 +1,47 @@
+// Package cache provides caching backends for generated applications.
+// It defines the Cache interface and provides MemoryCache (LRU+TTL)
+// and SQLiteCache (persistent) implementations.
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+// Cache is the interface for cache backends.
+// Get returns (value, found, error). A nil error with found=false means cache miss.
+type Cache interface {
+	Get(ctx context.Context, key string) ([]byte, bool, error)
+	Set(ctx context.Context, key string, value []byte, ttl time.Duration) error
+	Delete(ctx context.Context, key string) error
+	Flush(ctx context.Context) error
+}
+
+// Closeable is optionally implemented by caches that need cleanup (e.g., stop background goroutines).
+type Closeable interface {
+	Close() error
+}
+
+// GetJSON retrieves a value from the cache and unmarshals it into the target type.
+func GetJSON[T any](c Cache, ctx context.Context, key string) (T, bool, error) {
+	var zero T
+	data, found, err := c.Get(ctx, key)
+	if err != nil || !found {
+		return zero, found, err
+	}
+	var result T
+	if err := json.Unmarshal(data, &result); err != nil {
+		return zero, false, err
+	}
+	return result, true, nil
+}
+
+// SetJSON marshals the value to JSON and stores it in the cache.
+func SetJSON(c Cache, ctx context.Context, key string, value any, ttl time.Duration) error {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	return c.Set(ctx, key, data, ttl)
+}

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1,0 +1,47 @@
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+type testPost struct {
+	Title   string `json:"title"`
+	Content string `json:"content"`
+}
+
+func TestGetSetJSON(t *testing.T) {
+	c := NewMemoryCache(100, time.Minute)
+	defer c.Close()
+	ctx := context.Background()
+
+	post := testPost{Title: "Hello", Content: "World"}
+	if err := SetJSON(c, ctx, "post:1", post, time.Minute); err != nil {
+		t.Fatalf("SetJSON() error = %v", err)
+	}
+
+	result, found, err := GetJSON[testPost](c, ctx, "post:1")
+	if err != nil {
+		t.Fatalf("GetJSON() error = %v", err)
+	}
+	if !found {
+		t.Fatal("GetJSON() found = false")
+	}
+	if result.Title != "Hello" || result.Content != "World" {
+		t.Errorf("GetJSON() = %+v, want {Title:Hello Content:World}", result)
+	}
+}
+
+func TestGetJSON_Miss(t *testing.T) {
+	c := NewMemoryCache(100, time.Minute)
+	defer c.Close()
+
+	_, found, err := GetJSON[testPost](c, context.Background(), "missing")
+	if err != nil {
+		t.Fatalf("GetJSON() error = %v", err)
+	}
+	if found {
+		t.Error("GetJSON() found = true for missing key")
+	}
+}

--- a/pkg/cache/http.go
+++ b/pkg/cache/http.go
@@ -1,0 +1,30 @@
+package cache
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// HTTPCache returns middleware that sets Cache-Control headers.
+// maxAge is the duration in seconds that the response may be cached.
+func HTTPCache(maxAge int) func(http.Handler) http.Handler {
+	value := fmt.Sprintf("public, max-age=%d", maxAge)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Cache-Control", value)
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// NoCache returns middleware that sets headers to prevent caching.
+func NoCache() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+			w.Header().Set("Pragma", "no-cache")
+			w.Header().Set("Expires", "0")
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/pkg/cache/http_test.go
+++ b/pkg/cache/http_test.go
@@ -1,0 +1,47 @@
+package cache
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHTTPCache(t *testing.T) {
+	handler := HTTPCache(3600)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	cc := rec.Header().Get("Cache-Control")
+	if cc != "public, max-age=3600" {
+		t.Errorf("Cache-Control = %q, want %q", cc, "public, max-age=3600")
+	}
+}
+
+func TestNoCache(t *testing.T) {
+	handler := NoCache()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	cc := rec.Header().Get("Cache-Control")
+	if cc != "no-cache, no-store, must-revalidate" {
+		t.Errorf("Cache-Control = %q, want %q", cc, "no-cache, no-store, must-revalidate")
+	}
+
+	pragma := rec.Header().Get("Pragma")
+	if pragma != "no-cache" {
+		t.Errorf("Pragma = %q, want %q", pragma, "no-cache")
+	}
+
+	expires := rec.Header().Get("Expires")
+	if expires != "0" {
+		t.Errorf("Expires = %q, want %q", expires, "0")
+	}
+}

--- a/pkg/cache/memory.go
+++ b/pkg/cache/memory.go
@@ -1,0 +1,156 @@
+package cache
+
+import (
+	"container/list"
+	"context"
+	"sync"
+	"time"
+)
+
+type memoryEntry struct {
+	key       string
+	value     []byte
+	expiresAt time.Time
+}
+
+// MemoryCache is an in-memory cache with LRU eviction and TTL expiration.
+type MemoryCache struct {
+	mu       sync.RWMutex
+	items    map[string]*list.Element
+	order    *list.List // front = most recently used
+	maxItems int
+	stop     chan struct{}
+}
+
+// NewMemoryCache creates an in-memory cache with the given capacity.
+// A background goroutine cleans up expired entries at cleanupInterval.
+// Call Close() to stop the cleanup goroutine.
+func NewMemoryCache(maxEntries int, cleanupInterval time.Duration) *MemoryCache {
+	if maxEntries <= 0 {
+		maxEntries = 1000
+	}
+	if cleanupInterval <= 0 {
+		cleanupInterval = time.Minute
+	}
+
+	c := &MemoryCache{
+		items:    make(map[string]*list.Element),
+		order:    list.New(),
+		maxItems: maxEntries,
+		stop:     make(chan struct{}),
+	}
+
+	go c.cleanup(cleanupInterval)
+	return c
+}
+
+func (c *MemoryCache) Get(_ context.Context, key string) ([]byte, bool, error) {
+	c.mu.RLock()
+	elem, ok := c.items[key]
+	if !ok {
+		c.mu.RUnlock()
+		return nil, false, nil
+	}
+	entry := elem.Value.(*memoryEntry)
+	if time.Now().After(entry.expiresAt) {
+		c.mu.RUnlock()
+		c.Delete(context.Background(), key)
+		return nil, false, nil
+	}
+	// Copy value to avoid data races
+	val := make([]byte, len(entry.value))
+	copy(val, entry.value)
+	c.mu.RUnlock()
+
+	// Promote to front (requires write lock)
+	c.mu.Lock()
+	c.order.MoveToFront(elem)
+	c.mu.Unlock()
+
+	return val, true, nil
+}
+
+func (c *MemoryCache) Set(_ context.Context, key string, value []byte, ttl time.Duration) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if elem, ok := c.items[key]; ok {
+		c.order.MoveToFront(elem)
+		entry := elem.Value.(*memoryEntry)
+		entry.value = make([]byte, len(value))
+		copy(entry.value, value)
+		entry.expiresAt = time.Now().Add(ttl)
+		return nil
+	}
+
+	// Evict LRU if at capacity
+	for len(c.items) >= c.maxItems {
+		back := c.order.Back()
+		if back == nil {
+			break
+		}
+		evicted := c.order.Remove(back).(*memoryEntry)
+		delete(c.items, evicted.key)
+	}
+
+	val := make([]byte, len(value))
+	copy(val, value)
+	entry := &memoryEntry{
+		key:       key,
+		value:     val,
+		expiresAt: time.Now().Add(ttl),
+	}
+	elem := c.order.PushFront(entry)
+	c.items[key] = elem
+	return nil
+}
+
+func (c *MemoryCache) Delete(_ context.Context, key string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if elem, ok := c.items[key]; ok {
+		c.order.Remove(elem)
+		delete(c.items, key)
+	}
+	return nil
+}
+
+func (c *MemoryCache) Flush(_ context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.items = make(map[string]*list.Element)
+	c.order.Init()
+	return nil
+}
+
+// Close stops the background cleanup goroutine.
+func (c *MemoryCache) Close() error {
+	close(c.stop)
+	return nil
+}
+
+func (c *MemoryCache) cleanup(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-c.stop:
+			return
+		case <-ticker.C:
+			c.removeExpired()
+		}
+	}
+}
+
+func (c *MemoryCache) removeExpired() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := time.Now()
+	for key, elem := range c.items {
+		entry := elem.Value.(*memoryEntry)
+		if now.After(entry.expiresAt) {
+			c.order.Remove(elem)
+			delete(c.items, key)
+		}
+	}
+}

--- a/pkg/cache/memory_test.go
+++ b/pkg/cache/memory_test.go
@@ -1,0 +1,146 @@
+package cache
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestMemoryCache_SetGet(t *testing.T) {
+	c := NewMemoryCache(100, time.Minute)
+	defer c.Close()
+	ctx := context.Background()
+
+	if err := c.Set(ctx, "key1", []byte("value1"), time.Minute); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	val, found, err := c.Get(ctx, "key1")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if !found {
+		t.Fatal("Get() found = false, want true")
+	}
+	if string(val) != "value1" {
+		t.Errorf("Get() = %q, want %q", val, "value1")
+	}
+}
+
+func TestMemoryCache_Miss(t *testing.T) {
+	c := NewMemoryCache(100, time.Minute)
+	defer c.Close()
+
+	_, found, err := c.Get(context.Background(), "nonexistent")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if found {
+		t.Error("Get() found = true for nonexistent key")
+	}
+}
+
+func TestMemoryCache_TTLExpiration(t *testing.T) {
+	c := NewMemoryCache(100, time.Minute)
+	defer c.Close()
+	ctx := context.Background()
+
+	c.Set(ctx, "expires", []byte("data"), 50*time.Millisecond)
+
+	time.Sleep(100 * time.Millisecond)
+
+	_, found, _ := c.Get(ctx, "expires")
+	if found {
+		t.Error("Get() found expired entry")
+	}
+}
+
+func TestMemoryCache_LRUEviction(t *testing.T) {
+	c := NewMemoryCache(3, time.Minute)
+	defer c.Close()
+	ctx := context.Background()
+
+	c.Set(ctx, "a", []byte("1"), time.Minute)
+	c.Set(ctx, "b", []byte("2"), time.Minute)
+	c.Set(ctx, "c", []byte("3"), time.Minute)
+
+	// Access "a" to make it most recently used
+	c.Get(ctx, "a")
+
+	// Add "d" — should evict "b" (least recently used)
+	c.Set(ctx, "d", []byte("4"), time.Minute)
+
+	_, found, _ := c.Get(ctx, "b")
+	if found {
+		t.Error("LRU should have evicted 'b'")
+	}
+
+	_, found, _ = c.Get(ctx, "a")
+	if !found {
+		t.Error("'a' should still be in cache (was accessed recently)")
+	}
+}
+
+func TestMemoryCache_Delete(t *testing.T) {
+	c := NewMemoryCache(100, time.Minute)
+	defer c.Close()
+	ctx := context.Background()
+
+	c.Set(ctx, "key", []byte("val"), time.Minute)
+	c.Delete(ctx, "key")
+
+	_, found, _ := c.Get(ctx, "key")
+	if found {
+		t.Error("Get() found deleted key")
+	}
+}
+
+func TestMemoryCache_Flush(t *testing.T) {
+	c := NewMemoryCache(100, time.Minute)
+	defer c.Close()
+	ctx := context.Background()
+
+	c.Set(ctx, "a", []byte("1"), time.Minute)
+	c.Set(ctx, "b", []byte("2"), time.Minute)
+	c.Flush(ctx)
+
+	_, foundA, _ := c.Get(ctx, "a")
+	_, foundB, _ := c.Get(ctx, "b")
+	if foundA || foundB {
+		t.Error("Flush() should clear all entries")
+	}
+}
+
+func TestMemoryCache_Overwrite(t *testing.T) {
+	c := NewMemoryCache(100, time.Minute)
+	defer c.Close()
+	ctx := context.Background()
+
+	c.Set(ctx, "key", []byte("old"), time.Minute)
+	c.Set(ctx, "key", []byte("new"), time.Minute)
+
+	val, _, _ := c.Get(ctx, "key")
+	if string(val) != "new" {
+		t.Errorf("Get() = %q after overwrite, want %q", val, "new")
+	}
+}
+
+func TestMemoryCache_ConcurrentAccess(t *testing.T) {
+	c := NewMemoryCache(1000, time.Minute)
+	defer c.Close()
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			key := fmt.Sprintf("key-%d", i)
+			c.Set(ctx, key, []byte("value"), time.Minute)
+			c.Get(ctx, key)
+		}(i)
+	}
+	wg.Wait()
+}

--- a/pkg/cache/sqlite.go
+++ b/pkg/cache/sqlite.go
@@ -1,0 +1,88 @@
+package cache
+
+import (
+	"context"
+	"database/sql"
+	"time"
+)
+
+// SQLiteCache is a cache backed by a SQLite database table.
+// Data persists across application restarts.
+type SQLiteCache struct {
+	db   *sql.DB
+	stop chan struct{}
+}
+
+// NewSQLiteCache creates a persistent cache using the given SQLite database.
+// It creates the _cache table if it doesn't exist.
+// A background goroutine cleans up expired entries at cleanupInterval.
+func NewSQLiteCache(db *sql.DB, cleanupInterval time.Duration) (*SQLiteCache, error) {
+	if cleanupInterval <= 0 {
+		cleanupInterval = 5 * time.Minute
+	}
+
+	_, err := db.Exec(`CREATE TABLE IF NOT EXISTS _cache (
+		key TEXT PRIMARY KEY,
+		value BLOB NOT NULL,
+		expires_at DATETIME NOT NULL
+	)`)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &SQLiteCache{db: db, stop: make(chan struct{})}
+	go c.cleanup(cleanupInterval)
+	return c, nil
+}
+
+func (c *SQLiteCache) Get(ctx context.Context, key string) ([]byte, bool, error) {
+	var value []byte
+	err := c.db.QueryRowContext(ctx,
+		`SELECT value FROM _cache WHERE key = ? AND expires_at > ?`, key, time.Now(),
+	).Scan(&value)
+	if err == sql.ErrNoRows {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	return value, true, nil
+}
+
+func (c *SQLiteCache) Set(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	expiresAt := time.Now().Add(ttl)
+	_, err := c.db.ExecContext(ctx,
+		`INSERT OR REPLACE INTO _cache (key, value, expires_at) VALUES (?, ?, ?)`,
+		key, value, expiresAt,
+	)
+	return err
+}
+
+func (c *SQLiteCache) Delete(ctx context.Context, key string) error {
+	_, err := c.db.ExecContext(ctx, `DELETE FROM _cache WHERE key = ?`, key)
+	return err
+}
+
+func (c *SQLiteCache) Flush(ctx context.Context) error {
+	_, err := c.db.ExecContext(ctx, `DELETE FROM _cache`)
+	return err
+}
+
+// Close stops the background cleanup goroutine.
+func (c *SQLiteCache) Close() error {
+	close(c.stop)
+	return nil
+}
+
+func (c *SQLiteCache) cleanup(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-c.stop:
+			return
+		case <-ticker.C:
+			c.db.Exec(`DELETE FROM _cache WHERE expires_at < ?`, time.Now())
+		}
+	}
+}

--- a/pkg/cache/sqlite_test.go
+++ b/pkg/cache/sqlite_test.go
@@ -1,0 +1,112 @@
+package cache
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+func newTestSQLiteCache(t *testing.T) *SQLiteCache {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("Failed to open SQLite: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	c, err := NewSQLiteCache(db, time.Minute)
+	if err != nil {
+		t.Fatalf("NewSQLiteCache() error = %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+	return c
+}
+
+func TestSQLiteCache_SetGet(t *testing.T) {
+	c := newTestSQLiteCache(t)
+	ctx := context.Background()
+
+	if err := c.Set(ctx, "key1", []byte("value1"), time.Minute); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	val, found, err := c.Get(ctx, "key1")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if !found {
+		t.Fatal("Get() found = false, want true")
+	}
+	if string(val) != "value1" {
+		t.Errorf("Get() = %q, want %q", val, "value1")
+	}
+}
+
+func TestSQLiteCache_Miss(t *testing.T) {
+	c := newTestSQLiteCache(t)
+
+	_, found, err := c.Get(context.Background(), "nonexistent")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if found {
+		t.Error("Get() found = true for nonexistent key")
+	}
+}
+
+func TestSQLiteCache_TTLExpiration(t *testing.T) {
+	c := newTestSQLiteCache(t)
+	ctx := context.Background()
+
+	c.Set(ctx, "expires", []byte("data"), 50*time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
+
+	_, found, _ := c.Get(ctx, "expires")
+	if found {
+		t.Error("Get() found expired entry")
+	}
+}
+
+func TestSQLiteCache_Delete(t *testing.T) {
+	c := newTestSQLiteCache(t)
+	ctx := context.Background()
+
+	c.Set(ctx, "key", []byte("val"), time.Minute)
+	c.Delete(ctx, "key")
+
+	_, found, _ := c.Get(ctx, "key")
+	if found {
+		t.Error("Get() found deleted key")
+	}
+}
+
+func TestSQLiteCache_Flush(t *testing.T) {
+	c := newTestSQLiteCache(t)
+	ctx := context.Background()
+
+	c.Set(ctx, "a", []byte("1"), time.Minute)
+	c.Set(ctx, "b", []byte("2"), time.Minute)
+	c.Flush(ctx)
+
+	_, foundA, _ := c.Get(ctx, "a")
+	_, foundB, _ := c.Get(ctx, "b")
+	if foundA || foundB {
+		t.Error("Flush() should clear all entries")
+	}
+}
+
+func TestSQLiteCache_Overwrite(t *testing.T) {
+	c := newTestSQLiteCache(t)
+	ctx := context.Background()
+
+	c.Set(ctx, "key", []byte("old"), time.Minute)
+	c.Set(ctx, "key", []byte("new"), time.Minute)
+
+	val, _, _ := c.Get(ctx, "key")
+	if string(val) != "new" {
+		t.Errorf("Get() = %q after overwrite, want %q", val, "new")
+	}
+}


### PR DESCRIPTION
## Summary

- New `pkg/cache/` package with `Cache` interface (Get/Set/Delete/Flush)
- `MemoryCache`: in-memory LRU eviction + TTL expiration, background cleanup, thread-safe
- `SQLiteCache`: persistent cache using app's existing SQLite DB, auto-creates `_cache` table
- `GetJSON`/`SetJSON` generic helpers for type-safe cached values
- `HTTPCache`/`NoCache` middleware for Cache-Control headers

## Test plan

- [x] MemoryCache: set/get, cache miss, TTL expiration, LRU eviction at capacity, delete, flush, overwrite
- [x] MemoryCache: concurrent access with 100 goroutines (race detector clean)
- [x] SQLiteCache: set/get, cache miss, TTL expiration, delete, flush, overwrite
- [x] JSON helpers: SetJSON/GetJSON round-trip with struct types
- [x] HTTP middleware: Cache-Control and no-cache header verification
- [x] All 18 tests pass with `-race` flag
- [x] Full test suite passes (zero regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)