### PR TITLE
fix: API route registration — use RegisterRoutes instead of sub-mux

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -1049,7 +1049,7 @@ func TestAPIResourceGeneration(t *testing.T) {
 		"HandleCreate method": "func (h *PostHandler) HandleCreate",
 		"HandleUpdate method": "func (h *PostHandler) HandleUpdate",
 		"HandleDelete method": "func (h *PostHandler) HandleDelete",
-		"Handler function":    "func Handler(queries *models.Queries) http.Handler",
+		"RegisterRoutes func": "func RegisterRoutes(mux *http.ServeMux, queries *models.Queries)",
 		"GET list route":      `"GET /api/v1/post"`,
 		"POST create route":   `"POST /api/v1/post"`,
 		"GET by ID route":     `"GET /api/v1/post/{id}"`,

--- a/internal/generator/api.go
+++ b/internal/generator/api.go
@@ -190,18 +190,12 @@ func GenerateAPI(basePath, moduleName, resourceName string, fields []parser.Fiel
 		}
 	}
 
-	// Inject route into main.go
+	// Inject API route registration into main.go
 	mainGoPath := findMainGo(basePath)
 	if mainGoPath != "" {
-		route := RouteInfo{
-			Path:        "/api/v1/" + resourceNameLower + "/",
-			PackageName: "api",
-			HandlerCall: "api.Handler(queries)",
-			ImportPath:  moduleName + "/app/api",
-		}
-		if err := InjectRoute(mainGoPath, route); err != nil {
-			fmt.Printf("⚠️  Could not auto-inject API route: %v\n", err)
-			fmt.Printf("   Add manually: http.Handle(\"/api/v1/%s/\", api.Handler(queries))\n", resourceNameLower)
+		if err := InjectAPIRegistration(mainGoPath, moduleName+"/app/api"); err != nil {
+			fmt.Printf("⚠️  Could not auto-inject API routes: %v\n", err)
+			fmt.Printf("   Add manually: api.RegisterRoutes(http.DefaultServeMux, queries)\n")
 		}
 	}
 

--- a/internal/generator/route_injector.go
+++ b/internal/generator/route_injector.go
@@ -484,3 +484,57 @@ func WrapExistingRoutesWithAuth(mainGoPath string, structName string) error {
 
 	return nil
 }
+
+// InjectAPIRegistration adds api.RegisterRoutes(http.DefaultServeMux, queries)
+// and the api package import to main.go.
+func InjectAPIRegistration(mainGoPath, importPath string) error {
+	data, err := os.ReadFile(mainGoPath)
+	if err != nil {
+		return fmt.Errorf("failed to read main.go: %w", err)
+	}
+
+	content := string(data)
+
+	// Check if already injected
+	if strings.Contains(content, "api.RegisterRoutes") {
+		return nil
+	}
+
+	// Add import
+	importLine := fmt.Sprintf("\t\"%s\"", importPath)
+	if !strings.Contains(content, importLine) {
+		// Find the import block and add the import
+		importMarker := "\"golang.org/x/time/rate\""
+		if strings.Contains(content, importMarker) {
+			content = strings.Replace(content, importMarker, importLine+"\n\n\t"+importMarker, 1)
+		}
+	}
+
+	// Enable queries variable if needed
+	if strings.Contains(content, "_, err := database.InitDB(dbPath)") {
+		content = strings.Replace(content, "_, err := database.InitDB(dbPath)", "queries, err := database.InitDB(dbPath)", 1)
+	}
+
+	// Add RegisterRoutes call at the TODO marker
+	todoMarker := "// TODO: Add routes here"
+	if idx := strings.Index(content, todoMarker); idx >= 0 {
+		// Find the end of the TODO line
+		lineEnd := strings.Index(content[idx:], "\n")
+		if lineEnd < 0 {
+			lineEnd = len(content) - idx
+		}
+		// Skip the Example comment line too
+		nextLineStart := idx + lineEnd + 1
+		if nextLineStart < len(content) && strings.Contains(content[nextLineStart:nextLineStart+80], "Example:") {
+			exampleEnd := strings.Index(content[nextLineStart:], "\n")
+			if exampleEnd >= 0 {
+				nextLineStart += exampleEnd + 1
+			}
+		}
+		insertPoint := nextLineStart
+		registrationLine := "\tapi.RegisterRoutes(http.DefaultServeMux, queries)\n"
+		content = content[:insertPoint] + registrationLine + content[insertPoint:]
+	}
+
+	return os.WriteFile(mainGoPath, []byte(content), 0644)
+}

--- a/internal/kits/system/multi/templates/api/handler.go.tmpl
+++ b/internal/kits/system/multi/templates/api/handler.go.tmpl
@@ -203,16 +203,14 @@ func (h *[[.ResourceNameSingular]]Handler) HandleDelete(w http.ResponseWriter, r
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// Handler returns an http.Handler for this API resource.
-func Handler(queries *models.Queries) http.Handler {
+// RegisterRoutes registers all API routes on the given mux.
+func RegisterRoutes(mux *http.ServeMux, queries *models.Queries) {
 	h := &[[.ResourceNameSingular]]Handler{Queries: queries}
-	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/v1/[[.ResourceNameLower]]", h.HandleList)
 	mux.HandleFunc("POST /api/v1/[[.ResourceNameLower]]", h.HandleCreate)
 	mux.HandleFunc("GET /api/v1/[[.ResourceNameLower]]/{id}", h.HandleGet)
 	mux.HandleFunc("PUT /api/v1/[[.ResourceNameLower]]/{id}", h.HandleUpdate)
 	mux.HandleFunc("DELETE /api/v1/[[.ResourceNameLower]]/{id}", h.HandleDelete)
-	return mux
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {

--- a/internal/kits/system/single/templates/api/handler.go.tmpl
+++ b/internal/kits/system/single/templates/api/handler.go.tmpl
@@ -203,16 +203,14 @@ func (h *[[.ResourceNameSingular]]Handler) HandleDelete(w http.ResponseWriter, r
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// Handler returns an http.Handler for this API resource.
-func Handler(queries *models.Queries) http.Handler {
+// RegisterRoutes registers all API routes on the given mux.
+func RegisterRoutes(mux *http.ServeMux, queries *models.Queries) {
 	h := &[[.ResourceNameSingular]]Handler{Queries: queries}
-	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/v1/[[.ResourceNameLower]]", h.HandleList)
 	mux.HandleFunc("POST /api/v1/[[.ResourceNameLower]]", h.HandleCreate)
 	mux.HandleFunc("GET /api/v1/[[.ResourceNameLower]]/{id}", h.HandleGet)
 	mux.HandleFunc("PUT /api/v1/[[.ResourceNameLower]]/{id}", h.HandleUpdate)
 	mux.HandleFunc("DELETE /api/v1/[[.ResourceNameLower]]/{id}", h.HandleDelete)
-	return mux
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {

--- a/testdata/golden/api_handler.go.golden
+++ b/testdata/golden/api_handler.go.golden
@@ -195,16 +195,14 @@ func (h *PostHandler) HandleDelete(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// Handler returns an http.Handler for this API resource.
-func Handler(queries *models.Queries) http.Handler {
+// RegisterRoutes registers all API routes on the given mux.
+func RegisterRoutes(mux *http.ServeMux, queries *models.Queries) {
 	h := &PostHandler{Queries: queries}
-	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/v1/post", h.HandleList)
 	mux.HandleFunc("POST /api/v1/post", h.HandleCreate)
 	mux.HandleFunc("GET /api/v1/post/{id}", h.HandleGet)
 	mux.HandleFunc("PUT /api/v1/post/{id}", h.HandleUpdate)
 	mux.HandleFunc("DELETE /api/v1/post/{id}", h.HandleDelete)
-	return mux
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {


### PR DESCRIPTION
## Problem

API endpoints returned 404 for all requests. The API handler's internal `http.ServeMux` with Go 1.22+ method routing (`GET /api/v1/posts`) doesn't work when registered as a subtree handler on the outer `DefaultServeMux` (`http.Handle("/api/v1/posts/", handler)`). The nested mux routing interferes.

Found via E2E testing — POST/GET/PUT/DELETE all returned 404.

## Fix

Change `Handler(queries) http.Handler` to `RegisterRoutes(mux, queries)` which registers each method-route directly on the provided mux. The generator now injects `api.RegisterRoutes(http.DefaultServeMux, queries)` instead of `http.Handle("/api/v1/.../", api.Handler(queries))`.

## Test plan

- [x] API content validation test updated
- [x] Full flow compile test passes (gen app → gen api → sqlc → build)
- [x] All tests pass
- [x] Verified via E2E: all 10 API operations work (list, create, get, update, delete, pagination, 404, 422, 400, content-type)

🤖 Generated with [Claude Code](https://claude.com/claude-code)