### PR TITLE
fix(ci): fix YAML parse error in components-independence workflow

### DIFF
--- a/.github/workflows/components-independence.yml
+++ b/.github/workflows/components-independence.yml
@@ -65,18 +65,7 @@ jobs:
           cd /tmp/test-import
           go mod init example.com/test-import
           go mod edit -replace github.com/livetemplate/lvt/components=$GITHUB_WORKSPACE/components
-          cat > main.go <<'GOEOF'
-package main
-
-import (
-	"fmt"
-	"github.com/livetemplate/lvt/components"
-)
-
-func main() {
-	fmt.Println(components.Version())
-}
-GOEOF
+          printf 'package main\n\nimport (\n\t"fmt"\n\t"github.com/livetemplate/lvt/components"\n)\n\nfunc main() {\n\tfmt.Println(components.Version())\n}\n' > main.go
           GOWORK=off go mod tidy
           GOWORK=off go build .
           GOWORK=off go run .

--- a/testing/chrome.go
+++ b/testing/chrome.go
@@ -23,10 +23,10 @@ const (
 	// Override with the LVT_CLIENT_CDN_URL environment variable to pin a specific version.
 	defaultClientCDNURL = "https://unpkg.com/@livetemplate/client@latest/dist/livetemplate-client.browser.js"
 	// defaultCSSCDNURL is the unpkg.com URL for the shared LiveTemplate CSS.
-	defaultCSSCDNURL = "https://unpkg.com/@livetemplate/client@latest/livetemplate.css"
-	clientCacheTTL   = 1 * time.Hour
-	clientCacheFile  = "livetemplate-client-latest.js"
-	cssCacheFile     = "livetemplate-latest.css"
+	defaultCSSCDNURL   = "https://unpkg.com/@livetemplate/client@latest/livetemplate.css"
+	clientCacheTTL     = 1 * time.Hour
+	clientCacheFile    = "livetemplate-client-latest.js"
+	cssCacheFile       = "livetemplate-latest.css"
 	clientFetchTimeout = 30 * time.Second
 )
 


### PR DESCRIPTION
## Summary
- The heredoc in the "Test external import" step had Go code starting at column 0 inside a YAML literal block scalar (`run: |`), which broke GitHub's YAML parser
- Replaced the `cat <<'GOEOF'` heredoc with `printf` to keep all content at the proper YAML indentation level
- This fixes the "workflow file issue" failures that appeared on every push to main

## Root cause
YAML literal block scalars require all content lines to be indented at least as far as the first content line. The Go code inside the heredoc (e.g., `package main`) had zero indentation, terminating the block scalar early and causing a YAML parse error.

## Test plan
- [ ] Verify CI no longer shows "workflow file issue" failures on push to main
- [ ] Verify the `components-independence` workflow runs correctly on a PR touching `components/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)