### PR TITLE
fix(testing): respect test PORT/LVT_DEV_MODE over inherited env

### DIFF
--- a/testing/chrome.go
+++ b/testing/chrome.go
@@ -455,7 +455,8 @@ func StartTestServer(t *testing.T, mainPath string, port int) *exec.Cmd {
 
 	t.Logf("Starting test server on port %s", portStr)
 	cmd := exec.Command("go", "run", mainPath)
-	cmd.Env = append(cmd.Environ(), "PORT="+portStr, "LVT_DEV_MODE=true")
+	// LVT_DEV_MODE=true so the spawned process uses the local client library
+	cmd.Env = append(os.Environ(), "PORT="+portStr, "LVT_DEV_MODE=true")
 
 	// Redirect output to prevent hanging I/O pipes
 	// Use nil to discard output (tests don't need server logs)

--- a/testing/chrome.go
+++ b/testing/chrome.go
@@ -455,10 +455,7 @@ func StartTestServer(t *testing.T, mainPath string, port int) *exec.Cmd {
 
 	t.Logf("Starting test server on port %s", portStr)
 	cmd := exec.Command("go", "run", mainPath)
-	cmd.Env = append([]string{
-		"PORT=" + portStr,
-		"LVT_DEV_MODE=true", // Use local client library in tests
-	}, cmd.Environ()...)
+	cmd.Env = append(cmd.Environ(), "PORT="+portStr, "LVT_DEV_MODE=true")
 
 	// Redirect output to prevent hanging I/O pipes
 	// Use nil to discard output (tests don't need server logs)


### PR DESCRIPTION
## Summary

- `StartTestServer` prepended `PORT=` and `LVT_DEV_MODE=true` before `cmd.Environ()`, but Go's exec resolves duplicate env keys with last-occurrence semantics — so any inherited `PORT`/`LVT_DEV_MODE` from the parent shell silently overrode the helper's intent.
- Putting the overrides last fixes the resolution. Verified empirically: with `PORT=8765` exported, an example test using this helper would spawn its server on 8765 (collision with whatever was already there) instead of the test's `GetFreePort()` pick.
- Side benefit: `LVT_DEV_MODE=true` is now pinned by the test infrastructure rather than overridable from the parent shell. That is the correct behavior — the previous bug just hid the ordering issue.

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./testing/` passes
- [x] Empirically verified the fix with leaked `PORT=8765` against an examples test that uses `StartTestServer` (counter): server now starts on the test-chosen port, not the leaked one
- [ ] CI green (e2e tests use this helper — they should still pass since the fix doesn't change clean-shell behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)