### PR TITLE
feat(testing): add RecordWSFrames as canonical WS-frame capture helper

### DIFF
--- a/testing/websocket.go
+++ b/testing/websocket.go
@@ -31,6 +31,17 @@ func NewWSMessageLogger() *WSMessageLogger {
 	}
 }
 
+// RecordWSFrames is the canonical entry point for capturing WebSocket frames
+// in chromedp tests. Equivalent to NewWSMessageLogger followed by Start, it
+// exists so per-test setup is one line and bounded-size assertions across
+// suites share a single implementation. The capture stops when ctx is
+// cancelled (typically via t.Cleanup of the chromedp context).
+func RecordWSFrames(ctx context.Context) *WSMessageLogger {
+	logger := NewWSMessageLogger()
+	logger.Start(ctx)
+	return logger
+}
+
 func (wl *WSMessageLogger) Start(ctx context.Context) {
 	chromedp.ListenTarget(ctx, func(ev interface{}) {
 		switch ev := ev.(type) {


### PR DESCRIPTION
## Summary

- Adds `e2etest.RecordWSFrames(ctx) *WSMessageLogger` — a one-line wrapper around `NewWSMessageLogger` + `Start(ctx)` so per-test setup is uniform across e2e suites
- Per livetemplate streaming-range proposal §379, this is the canonical entry point for bounded-WS-size assertions; ensures multiple test files don't reinvent the setup ritual

## Test plan

- [x] \`go test ./testing/...\` green
- [x] Used by examples \`patterns_test.go\` \`TestLargeTable_Update_Random_Row_Bounded_WS_Frame\` (separate PR in examples repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)