### PR TITLE
ci: dispatch livetemplate/docs sync on release tag

### DIFF
--- a/.github/workflows/dispatch-docs-sync.yml
+++ b/.github/workflows/dispatch-docs-sync.yml
@@ -1,0 +1,31 @@
+# When a release tag is pushed to this repo, fire a repository_dispatch
+# event into livetemplate/docs so its sync workflow mirrors the new
+# version's markdown. See livetemplate/docs/CONTRIBUTING.md → Sync workflow
+# for the receiving end.
+name: dispatch docs sync
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fire repository_dispatch into livetemplate/docs
+        env:
+          # PAT with `Contents: Read and write` on livetemplate/docs.
+          # Same PAT used by all four source repos. Setup once via:
+          #   gh secret set DOCS_DISPATCH_TOKEN --repo livetemplate/<this> --body <token>
+          GH_TOKEN: ${{ secrets.DOCS_DISPATCH_TOKEN }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::warning::DOCS_DISPATCH_TOKEN not set; skipping docs sync dispatch"
+            exit 0
+          fi
+          gh api -X POST /repos/livetemplate/docs/dispatches \
+            -F event_type=sync-source \
+            -F "client_payload[source_repo]=https://github.com/${{ github.repository }}" \
+            -F "client_payload[ref]=${{ github.ref_name }}"
+          echo "::notice::dispatched docs sync for ${{ github.ref_name }}"


### PR DESCRIPTION
Adds a `dispatch docs sync` workflow that fires a `repository_dispatch` event into `livetemplate/docs` when a release tag (`v*`) is pushed. The docs site's [sync workflow](https://github.com/livetemplate/docs/blob/main/.github/workflows/sync.yml) listens for this event and opens a PR with refreshed mirrored content.

This is the source-repo half of the Phase 3 sync automation in `livetemplate/docs`. The receiving end is already live and tested via `workflow_dispatch`; merging this PR completes the auto-trigger.

## Setup required after merge

The workflow needs a `DOCS_DISPATCH_TOKEN` secret to call `gh api /repos/livetemplate/docs/dispatches`. Without it the workflow runs but no-ops with a warning. Setup:

```
gh secret set DOCS_DISPATCH_TOKEN --repo livetemplate/<this-repo> --body <pat>
```

The PAT needs only `Contents: Read and write` on `livetemplate/docs`. The same PAT works across all four source repos.

## Behavior without the secret

The workflow runs on every tag push, finds no token, logs a warning, and exits 0. Safe to merge before the secret is configured.

🤖 Part of the LiveTemplate docs site Phase 3 automation. See livetemplate/docs/CONTRIBUTING.md → Sync workflow.