### PR TITLE
docs(README): cross-link to https://livetemplate.fly.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Phoenix-inspired code generator for LiveTemplate applications with CRUD functionality and interactive TUI wizards.
 
+📚 **Framework documentation:** **<https://livetemplate.fly.dev>** — guides, recipes, patterns catalog. The `/cli` section covers `lvt` specifically.
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
Add prominent link to the public framework docs site at the top of the README. The `/cli` section there covers `lvt` specifically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)