### PR TITLE
test(e2e): pin explicit-submitter round-trip via chromedp

### DIFF
--- a/e2e/livetemplate_core_test.go
+++ b/e2e/livetemplate_core_test.go
@@ -2451,10 +2451,19 @@ func TestExplicitSubmitter_E2E(t *testing.T) {
 	wsLog := e2etest.RecordWSFrames(ctx)
 	pageURL := e2etest.GetChromeTestURL(port)
 
+	// Wait for the wrapper's data-lvt-loading attribute to clear — that's the
+	// framework's "WS connected, client initialized" signal (set server-side,
+	// removed by the JS client once the socket handshake completes). Waiting
+	// on `typeof window.liveTemplateClient !== 'undefined'` would fire after
+	// the script tag evaluates but before the WS is open, so a fast click
+	// could be swallowed silently.
 	if err := chromedp.Run(ctx,
 		chromedp.Navigate(pageURL),
 		chromedp.WaitVisible(`#btn-save`, chromedp.ByID),
-		e2etest.WaitFor(`typeof window.liveTemplateClient !== 'undefined'`, 5*time.Second),
+		e2etest.WaitFor(`(() => {
+			const w = document.querySelector('[data-lvt-id]');
+			return w && !w.hasAttribute('data-lvt-loading');
+		})()`, 5*time.Second),
 	); err != nil {
 		t.Fatalf("boot: %v", err)
 	}

--- a/e2e/livetemplate_core_test.go
+++ b/e2e/livetemplate_core_test.go
@@ -2472,7 +2472,7 @@ func TestExplicitSubmitter_E2E(t *testing.T) {
 		wsLog.Print()
 		t.Fatalf("save click: %v", err)
 	}
-	saveMsg, err := wsLog.WaitForMessage(`"submitter":"save"`, 3*time.Second)
+	saveMsg, err := wsLog.WaitForSentMessage(`"submitter":"save"`, 3*time.Second)
 	if err != nil {
 		wsLog.PrintLast(10)
 		t.Fatalf(`expected WS sent frame containing "submitter":"save": %v`, err)
@@ -2501,7 +2501,7 @@ func TestExplicitSubmitter_E2E(t *testing.T) {
 		wsLog.Print()
 		t.Fatalf("delete click: %v", err)
 	}
-	delMsg, err := wsLog.WaitForMessage(`"submitter":"delete"`, 3*time.Second)
+	delMsg, err := wsLog.WaitForSentMessage(`"submitter":"delete"`, 3*time.Second)
 	if err != nil {
 		wsLog.PrintLast(10)
 		t.Fatalf(`expected WS sent frame containing "submitter":"delete": %v`, err)

--- a/e2e/livetemplate_core_test.go
+++ b/e2e/livetemplate_core_test.go
@@ -2393,7 +2393,7 @@ func (c *SubmitterTestController) Delete(state SubmitterTestState, _ *livetempla
 // cannot pass.
 func TestExplicitSubmitter_E2E(t *testing.T) {
 	controller := &SubmitterTestController{}
-	state := &SubmitterTestState{Counter: 0, Status: "idle"}
+	state := &SubmitterTestState{Status: "idle"}
 
 	tmpl := livetemplate.Must(livetemplate.New("submitter-e2e"))
 	templateStr := `<!DOCTYPE html>
@@ -2461,9 +2461,13 @@ func TestExplicitSubmitter_E2E(t *testing.T) {
 
 	// Click "save" — dispatch must hit Save() so status flips to "saved" and
 	// counter becomes 1. The WS frame must carry the explicit submitter field.
+	// Clear the frame log first so the assertion only sees frames produced by
+	// this click, making the ordering contract explicit instead of relying on
+	// "save" and "delete" being disjoint substrings.
+	wsLog.Clear()
 	if err := chromedp.Run(ctx,
 		chromedp.Click(`#btn-save`, chromedp.ByID),
-		e2etest.WaitFor(`document.getElementById('status').textContent === 'saved'`, 5*time.Second),
+		e2etest.WaitFor(`document.getElementById('status').textContent.trim() === 'saved'`, 5*time.Second),
 	); err != nil {
 		wsLog.Print()
 		t.Fatalf("save click: %v", err)
@@ -2489,9 +2493,10 @@ func TestExplicitSubmitter_E2E(t *testing.T) {
 
 	// Click "delete" — dispatch must hit Delete() (opposite mutation),
 	// proving the resolution is button-specific and not stuck on "save".
+	wsLog.Clear()
 	if err := chromedp.Run(ctx,
 		chromedp.Click(`#btn-delete`, chromedp.ByID),
-		e2etest.WaitFor(`document.getElementById('status').textContent === 'deleted'`, 5*time.Second),
+		e2etest.WaitFor(`document.getElementById('status').textContent.trim() === 'deleted'`, 5*time.Second),
 	); err != nil {
 		wsLog.Print()
 		t.Fatalf("delete click: %v", err)
@@ -2503,6 +2508,9 @@ func TestExplicitSubmitter_E2E(t *testing.T) {
 	}
 	if got, _ := delMsg.Parsed["submitter"].(string); got != "delete" {
 		t.Errorf(`WS submitter: got %q, want "delete"`, got)
+	}
+	if got, _ := delMsg.Parsed["action"].(string); got != "delete" {
+		t.Errorf(`WS action: got %q, want "delete"`, got)
 	}
 	var counterAfterDelete string
 	if err := chromedp.Run(ctx, chromedp.Text(`#counter`, &counterAfterDelete, chromedp.ByID)); err != nil {

--- a/e2e/livetemplate_core_test.go
+++ b/e2e/livetemplate_core_test.go
@@ -2353,3 +2353,162 @@ func TestTemplate_E2E_ComponentBased(t *testing.T) {
 		t.Logf("✅ Component-based template updates work - JSON length: %d bytes", len(updateJSON))
 	})
 }
+
+// SubmitterTestController is a singleton for the explicit-submitter E2E test.
+type SubmitterTestController struct{}
+
+// SubmitterTestState is the pure-data state for SubmitterTestController.
+type SubmitterTestState struct {
+	Counter int
+	Status  string
+}
+
+// Save runs when the form submits via <button name="save">. Reaching this
+// method is the round-trip assertion: the server resolved ctx.Action()=="save"
+// from the explicit submitter the client emitted, not from any heuristic.
+func (c *SubmitterTestController) Save(state SubmitterTestState, _ *livetemplate.Context) (SubmitterTestState, error) {
+	state.Counter++
+	state.Status = "saved"
+	return state, nil
+}
+
+// Delete runs when the form submits via <button name="delete">.
+func (c *SubmitterTestController) Delete(state SubmitterTestState, _ *livetemplate.Context) (SubmitterTestState, error) {
+	state.Counter = 0
+	state.Status = "deleted"
+	return state, nil
+}
+
+// TestExplicitSubmitter_E2E pins the round-trip contract for the explicit
+// submitter wire field documented in docs/proposals/explicit-submitter.md
+// (livetemplate#237, Verification item 3).
+//
+// With @livetemplate/client v0.9.0+, a form submission via a named submit
+// button auto-intercepts onto the WebSocket and emits an explicit "submitter"
+// JSON field carrying the button's name. The server then dispatches via
+// resolveSubmitterFallback so ctx.Action() equals the button name — no
+// reliance on the empty-value heuristic that the explicit field replaces for
+// JS-enabled clients. Two distinct clicks (save, delete) move state in
+// opposite directions, so a stuck dispatch (always "save" or always "delete")
+// cannot pass.
+func TestExplicitSubmitter_E2E(t *testing.T) {
+	controller := &SubmitterTestController{}
+	state := &SubmitterTestState{Counter: 0, Status: "idle"}
+
+	tmpl := livetemplate.Must(livetemplate.New("submitter-e2e"))
+	templateStr := `<!DOCTYPE html>
+<html>
+<head><title>Submitter E2E</title></head>
+<body>
+	<div>Counter: <span id="counter">{{.Counter}}</span></div>
+	<div>Status: <span id="status">{{.Status}}</span></div>
+	<form id="actions">
+		<button type="submit" name="save" id="btn-save">Save</button>
+		<button type="submit" name="delete" id="btn-delete">Delete</button>
+	</form>
+	<script src="/client.js"></script>
+</body>
+</html>`
+	if _, err := tmpl.Parse(templateStr); err != nil {
+		t.Fatalf("parse template: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/", tmpl.Handle(controller, livetemplate.AsState(state)))
+	mux.HandleFunc("/client.js", e2etest.ServeClientLibrary)
+
+	port, err := e2etest.GetFreePort()
+	if err != nil {
+		t.Fatalf("get free port: %v", err)
+	}
+	server := &http.Server{Addr: fmt.Sprintf(":%d", port), Handler: mux}
+	go func() {
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Printf("server error: %v", err)
+		}
+	}()
+	e2etest.WaitForServer(t, fmt.Sprintf("http://localhost:%d", port), 10*time.Second)
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			t.Logf("server shutdown warning: %v", err)
+		}
+	}()
+
+	chromeCtx, cleanup := e2etest.SetupDockerChrome(t, 30*time.Second)
+	defer cleanup()
+	ctx := chromeCtx.Context
+
+	chromedp.ListenTarget(ctx, func(ev interface{}) {
+		if ev, ok := ev.(*runtime.EventConsoleAPICalled); ok {
+			for _, arg := range ev.Args {
+				log.Printf("Console: %s", string(arg.Value))
+			}
+		}
+	})
+
+	wsLog := e2etest.RecordWSFrames(ctx)
+	pageURL := e2etest.GetChromeTestURL(port)
+
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(pageURL),
+		chromedp.WaitVisible(`#btn-save`, chromedp.ByID),
+		e2etest.WaitFor(`typeof window.liveTemplateClient !== 'undefined'`, 5*time.Second),
+	); err != nil {
+		t.Fatalf("boot: %v", err)
+	}
+
+	// Click "save" — dispatch must hit Save() so status flips to "saved" and
+	// counter becomes 1. The WS frame must carry the explicit submitter field.
+	if err := chromedp.Run(ctx,
+		chromedp.Click(`#btn-save`, chromedp.ByID),
+		e2etest.WaitFor(`document.getElementById('status').textContent === 'saved'`, 5*time.Second),
+	); err != nil {
+		wsLog.Print()
+		t.Fatalf("save click: %v", err)
+	}
+	saveMsg, err := wsLog.WaitForMessage(`"submitter":"save"`, 3*time.Second)
+	if err != nil {
+		wsLog.PrintLast(10)
+		t.Fatalf(`expected WS sent frame containing "submitter":"save": %v`, err)
+	}
+	if got, _ := saveMsg.Parsed["submitter"].(string); got != "save" {
+		t.Errorf(`WS submitter: got %q, want "save"`, got)
+	}
+	if got, _ := saveMsg.Parsed["action"].(string); got != "save" {
+		t.Errorf(`WS action: got %q, want "save"`, got)
+	}
+	var counterAfterSave string
+	if err := chromedp.Run(ctx, chromedp.Text(`#counter`, &counterAfterSave, chromedp.ByID)); err != nil {
+		t.Fatal(err)
+	}
+	if counterAfterSave != "1" {
+		t.Errorf("counter after save: got %q, want %q", counterAfterSave, "1")
+	}
+
+	// Click "delete" — dispatch must hit Delete() (opposite mutation),
+	// proving the resolution is button-specific and not stuck on "save".
+	if err := chromedp.Run(ctx,
+		chromedp.Click(`#btn-delete`, chromedp.ByID),
+		e2etest.WaitFor(`document.getElementById('status').textContent === 'deleted'`, 5*time.Second),
+	); err != nil {
+		wsLog.Print()
+		t.Fatalf("delete click: %v", err)
+	}
+	delMsg, err := wsLog.WaitForMessage(`"submitter":"delete"`, 3*time.Second)
+	if err != nil {
+		wsLog.PrintLast(10)
+		t.Fatalf(`expected WS sent frame containing "submitter":"delete": %v`, err)
+	}
+	if got, _ := delMsg.Parsed["submitter"].(string); got != "delete" {
+		t.Errorf(`WS submitter: got %q, want "delete"`, got)
+	}
+	var counterAfterDelete string
+	if err := chromedp.Run(ctx, chromedp.Text(`#counter`, &counterAfterDelete, chromedp.ByID)); err != nil {
+		t.Fatal(err)
+	}
+	if counterAfterDelete != "0" {
+		t.Errorf("counter after delete: got %q, want %q", counterAfterDelete, "0")
+	}
+}

--- a/e2e/livetemplate_core_test.go
+++ b/e2e/livetemplate_core_test.go
@@ -2410,7 +2410,7 @@ func TestExplicitSubmitter_E2E(t *testing.T) {
 </body>
 </html>`
 	if _, err := tmpl.Parse(templateStr); err != nil {
-		t.Fatalf("parse template: %v", err)
+		t.Fatalf("Failed to parse template: %v", err)
 	}
 
 	mux := http.NewServeMux()
@@ -2419,12 +2419,12 @@ func TestExplicitSubmitter_E2E(t *testing.T) {
 
 	port, err := e2etest.GetFreePort()
 	if err != nil {
-		t.Fatalf("get free port: %v", err)
+		t.Fatalf("Failed to get free port: %v", err)
 	}
 	server := &http.Server{Addr: fmt.Sprintf(":%d", port), Handler: mux}
 	go func() {
 		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Printf("server error: %v", err)
+			log.Printf("Server error: %v", err)
 		}
 	}()
 	e2etest.WaitForServer(t, fmt.Sprintf("http://localhost:%d", port), 10*time.Second)
@@ -2472,10 +2472,14 @@ func TestExplicitSubmitter_E2E(t *testing.T) {
 		wsLog.Print()
 		t.Fatalf("save click: %v", err)
 	}
-	saveMsg, err := wsLog.WaitForSentMessage(`"submitter":"save"`, 3*time.Second)
+	// Match on the field key only and assert the value via Parsed so the test
+	// doesn't couple to JSON serialization spacing (e.g. `"submitter":"save"`
+	// vs `"submitter": "save"`). Clear() above guarantees this matches the
+	// click-induced frame, not earlier handshake traffic.
+	saveMsg, err := wsLog.WaitForSentMessage(`"submitter"`, 3*time.Second)
 	if err != nil {
 		wsLog.PrintLast(10)
-		t.Fatalf(`expected WS sent frame containing "submitter":"save": %v`, err)
+		t.Fatalf(`expected WS sent frame containing "submitter" field: %v`, err)
 	}
 	if got, _ := saveMsg.Parsed["submitter"].(string); got != "save" {
 		t.Errorf(`WS submitter: got %q, want "save"`, got)
@@ -2501,10 +2505,10 @@ func TestExplicitSubmitter_E2E(t *testing.T) {
 		wsLog.Print()
 		t.Fatalf("delete click: %v", err)
 	}
-	delMsg, err := wsLog.WaitForSentMessage(`"submitter":"delete"`, 3*time.Second)
+	delMsg, err := wsLog.WaitForSentMessage(`"submitter"`, 3*time.Second)
 	if err != nil {
 		wsLog.PrintLast(10)
-		t.Fatalf(`expected WS sent frame containing "submitter":"delete": %v`, err)
+		t.Fatalf(`expected WS sent frame containing "submitter" field: %v`, err)
 	}
 	if got, _ := delMsg.Parsed["submitter"].(string); got != "delete" {
 		t.Errorf(`WS submitter: got %q, want "delete"`, got)

--- a/testing/websocket.go
+++ b/testing/websocket.go
@@ -243,6 +243,23 @@ func (wl *WSMessageLogger) WaitForMessage(pattern string, timeout time.Duration)
 	return WSMessage{}, fmt.Errorf("timeout waiting for message matching '%s'", pattern)
 }
 
+// WaitForSentMessage is like WaitForMessage but restricts the search to
+// browser→server frames. Use this when asserting on a wire-contract field
+// the client emits — direction-blind matching can otherwise pass against a
+// server frame that happens to echo the same substring.
+func (wl *WSMessageLogger) WaitForSentMessage(pattern string, timeout time.Duration) (WSMessage, error) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		for _, msg := range wl.GetSent() {
+			if strings.Contains(msg.Data, pattern) {
+				return msg, nil
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return WSMessage{}, fmt.Errorf("timeout waiting for sent message matching '%s'", pattern)
+}
+
 func (wl *WSMessageLogger) Print() {
 	wl.mu.RLock()
 	defer wl.mu.RUnlock()

--- a/testing/websocket.go
+++ b/testing/websocket.go
@@ -243,10 +243,7 @@ func (wl *WSMessageLogger) WaitForMessage(pattern string, timeout time.Duration)
 	return WSMessage{}, fmt.Errorf("timeout waiting for message matching '%s'", pattern)
 }
 
-// WaitForSentMessage is like WaitForMessage but restricts the search to
-// browser→server frames. Use this when asserting on a wire-contract field
-// the client emits — direction-blind matching can otherwise pass against a
-// server frame that happens to echo the same substring.
+// WaitForSentMessage is WaitForMessage restricted to browser→server frames.
 func (wl *WSMessageLogger) WaitForSentMessage(pattern string, timeout time.Duration) (WSMessage, error) {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {

--- a/testing/websocket.go
+++ b/testing/websocket.go
@@ -243,14 +243,25 @@ func (wl *WSMessageLogger) WaitForMessage(pattern string, timeout time.Duration)
 	return WSMessage{}, fmt.Errorf("timeout waiting for message matching '%s'", pattern)
 }
 
+// FindSentMessage scans browser→server frames for pattern.
+func (wl *WSMessageLogger) FindSentMessage(pattern string) (WSMessage, bool) {
+	wl.mu.RLock()
+	defer wl.mu.RUnlock()
+
+	for _, msg := range wl.messages {
+		if msg.Direction == "sent" && strings.Contains(msg.Data, pattern) {
+			return msg, true
+		}
+	}
+	return WSMessage{}, false
+}
+
 // WaitForSentMessage is WaitForMessage restricted to browser→server frames.
 func (wl *WSMessageLogger) WaitForSentMessage(pattern string, timeout time.Duration) (WSMessage, error) {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		for _, msg := range wl.GetSent() {
-			if strings.Contains(msg.Data, pattern) {
-				return msg, nil
-			}
+		if msg, found := wl.FindSentMessage(pattern); found {
+			return msg, nil
 		}
 		time.Sleep(100 * time.Millisecond)
 	}


### PR DESCRIPTION
## Summary

Adds `TestExplicitSubmitter_E2E` in `e2e/livetemplate_core_test.go`, covering Verification item 3 of [the explicit-submitter proposal](https://github.com/livetemplate/livetemplate/blob/main/docs/proposals/explicit-submitter.md): a real-browser round-trip of the explicit `submitter` WS field that `@livetemplate/client` v0.9.0 emits.

A form with two named submit buttons (`save`, `delete`) auto-intercepts onto the WebSocket; the test asserts the WS sent frame contains `"submitter":"save"` then `"submitter":"delete"`, and that the controller dispatches to the matching method (counter increments on save, resets on delete). The two opposite-direction mutations rule out a stuck dispatch (always-"save" or always-"delete" would fail).

This closes the cross-repo verification gap from [livetemplate#237 Phase 2](https://github.com/livetemplate/livetemplate/issues/237) (PR #396 server-side, [client#120](https://github.com/livetemplate/client/pull/120) client-side, released as `@livetemplate/client@0.9.0`).

## Test plan

- [x] `GOWORK=off go test -tags browser -run '^TestExplicitSubmitter_E2E$' -v ./e2e/` passes locally (CDN-resolved `@livetemplate/client@0.9.0` via `unpkg/@latest`)
- [x] WS frames captured via `RecordWSFrames` show the explicit `"submitter"` JSON key on both clicks
- [x] Server-side dispatch reaches `Save()` then `Delete()` (counter flips 0→1→0; status flips idle→saved→deleted)
- [x] `go vet -tags browser ./e2e/` clean
- [x] No new lint findings introduced by this change