### PR TITLE
test(e2e): chromedp coverage for lifecycle ergonomics (livetemplate#408)

### DIFF
--- a/e2e/lifecycle_ergonomics_test.go
+++ b/e2e/lifecycle_ergonomics_test.go
@@ -1,0 +1,355 @@
+//go:build browser
+
+package e2e_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chromedp/cdproto/runtime"
+	"github.com/chromedp/chromedp"
+	"github.com/gorilla/websocket"
+	"github.com/livetemplate/livetemplate"
+	e2etest "github.com/livetemplate/lvt/testing"
+)
+
+// =============================================================================
+// E2E coverage for the lifecycle-ergonomics batch (#339, #340, #341, #345).
+//
+// Verifies the browser-observable behavior end-to-end against a real Chromium
+// and a real livetemplate http.Handler. Per CLAUDE.md (global): chromedp e2e
+// tests surface (1) browser console, (2) server logs, (3) websocket messages,
+// (4) rendered HTML.
+//
+// Important semantic note observed during test development:
+//
+//   In a normal browser flow — HTTP GET → server-renders HTML → WS connects —
+//   the framework persists state at the end of the HTTP Mount. When the WS
+//   then connects, `restorePersistedState` returns ok, which is the signal
+//   that flips IsReconnect() to true. So even on a "fresh" tab load,
+//   `ctx.IsReconnect()` is true inside the WS-path Mount/OnConnect.
+//
+//   IsInitialMount(), by contrast, is only true on the actual HTTP GET. By
+//   the time the WS has connected, OnConnect has overwritten state with
+//   IsInitialMount=false. To assert IsInitialMount=true you must inspect the
+//   server-rendered HTML before the WS arrives — these tests use http.Get
+//   for that, not the chromedp DOM.
+// =============================================================================
+
+type lifecycleE2EState struct {
+	// Count is persisted so a WS reconnect restores prior state — that
+	// restoration is precisely what IsReconnect() reads.
+	Count int `lvt:"persist"`
+
+	// Tags carry the connect-kind helpers' values out to the DOM/HTML so the
+	// test can read them. Persist them too so the *most recent* lifecycle
+	// call wins regardless of which path (HTTP vs WS) ran last.
+	InitialMountTag string `lvt:"persist"`
+	ReconnectTag    string `lvt:"persist"`
+}
+
+type lifecycleE2EController struct{}
+
+func (c *lifecycleE2EController) Mount(state lifecycleE2EState, ctx *livetemplate.Context) (lifecycleE2EState, error) {
+	state.InitialMountTag = boolTag(ctx.IsInitialMount())
+	state.ReconnectTag = boolTag(ctx.IsReconnect())
+	return state, nil
+}
+
+func (c *lifecycleE2EController) OnConnect(state lifecycleE2EState, ctx *livetemplate.Context) (lifecycleE2EState, error) {
+	// OnConnect overwrites the tags so the DOM reflects the WS-path classification.
+	state.InitialMountTag = boolTag(ctx.IsInitialMount())
+	state.ReconnectTag = boolTag(ctx.IsReconnect())
+	state.Count++
+	return state, nil
+}
+
+func (c *lifecycleE2EController) SetFlashes(state lifecycleE2EState, ctx *livetemplate.Context) (lifecycleE2EState, error) {
+	ctx.SetFlash("success", "Saved!")
+	ctx.SetFlash("info", "Heads up")
+	return state, nil
+}
+
+func (c *lifecycleE2EController) ClearFlashes(state lifecycleE2EState, ctx *livetemplate.Context) (lifecycleE2EState, error) {
+	ctx.ClearAllFlash()
+	return state, nil
+}
+
+func boolTag(b bool) string {
+	if b {
+		return "YES"
+	}
+	return "NO"
+}
+
+const lifecycleE2ETemplate = `<!DOCTYPE html>
+<html>
+<head><title>Lifecycle E2E</title></head>
+<body>
+  <div id="im">im={{.InitialMountTag}}</div>
+  <div id="rc">rc={{.ReconnectTag}}</div>
+  <div id="count">count={{.Count}}</div>
+  <div id="flash-success">{{.lvt.Flash "success"}}</div>
+  <div id="flash-info">{{.lvt.Flash "info"}}</div>
+  <button id="set-flashes" lvt-on:click="SetFlashes">Set flashes</button>
+  <button id="clear-flashes" lvt-on:click="ClearFlashes">Clear all</button>
+  <script src="/client.js"></script>
+</body>
+</html>`
+
+// startLifecycleE2EServer boots an in-process http.Server with the test
+// handler. Mirrors TestLoadingIndicator's setup pattern.
+func startLifecycleE2EServer(t *testing.T) (baseURL string, port int, shutdown func()) {
+	t.Helper()
+
+	tmpl := livetemplate.Must(livetemplate.New("lifecycle-e2e"))
+	if _, err := tmpl.Parse(lifecycleE2ETemplate); err != nil {
+		t.Fatalf("parse template: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/", tmpl.Handle(&lifecycleE2EController{}, livetemplate.AsState(&lifecycleE2EState{})))
+	mux.HandleFunc("/client.js", e2etest.ServeClientLibrary)
+
+	p, err := e2etest.GetFreePort()
+	if err != nil {
+		t.Fatalf("free port: %v", err)
+	}
+	server := &http.Server{Addr: fmt.Sprintf(":%d", p), Handler: mux}
+
+	go func() {
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Printf("server: %v", err)
+		}
+	}()
+
+	url := fmt.Sprintf("http://localhost:%d", p)
+	e2etest.WaitForServer(t, url, 10*time.Second)
+
+	return url, p, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = server.Shutdown(ctx)
+	}
+}
+
+// installConsoleLogger pipes browser console.* calls into t.Logf so failures
+// are debuggable without a re-run.
+func installConsoleLogger(t *testing.T, ctx context.Context) {
+	t.Helper()
+	chromedp.ListenTarget(ctx, func(ev interface{}) {
+		if call, ok := ev.(*runtime.EventConsoleAPICalled); ok {
+			parts := make([]string, 0, len(call.Args))
+			for _, a := range call.Args {
+				parts = append(parts, string(a.Value))
+			}
+			t.Logf("[console.%s] %s", call.Type, strings.Join(parts, " "))
+		}
+	})
+}
+
+// waitForCondition polls a JS expression until it returns true or the timeout
+// elapses. Used for "DOM should reflect X after WS round-trip" assertions.
+func waitForCondition(t *testing.T, ctx context.Context, jsExpr string, timeout time.Duration, why string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		var ok bool
+		if err := chromedp.Run(ctx, chromedp.Evaluate(jsExpr, &ok)); err == nil && ok {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	var html string
+	_ = chromedp.Run(ctx, chromedp.OuterHTML("body", &html, chromedp.ByQuery))
+	t.Fatalf("timed out waiting for %s. Final DOM:\n%s", why, html)
+}
+
+// =============================================================================
+// Test 1 — Issue #340: IsInitialMount fires on the initial HTTP GET.
+// The server-rendered HTML (before the WS even connects) must reflect
+// IsInitialMount()=true. After the WS connects and OnConnect runs, the DOM
+// flips to im=NO because OnConnect's context is from the WS path.
+// =============================================================================
+
+func TestE2E_IsInitialMount_RendersInInitialHTML(t *testing.T) {
+	baseURL, _, shutdown := startLifecycleE2EServer(t)
+	defer shutdown()
+
+	// 1. The server-rendered HTML — captured BEFORE any WS connects — must
+	// reflect IsInitialMount()=true. http.Get takes no WS round-trip, so
+	// this isolates the HTTP-path Mount classification.
+	resp, err := http.Get(baseURL)
+	if err != nil {
+		t.Fatalf("http.Get: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	html := string(body)
+
+	if !strings.Contains(html, ">im=YES<") {
+		t.Errorf("server-rendered HTML missing im=YES (IsInitialMount wiring broken on HTTP path).\nHTML:\n%s", html)
+	}
+	if !strings.Contains(html, ">rc=NO<") {
+		t.Errorf("server-rendered HTML missing rc=NO (initial GET should not be a reconnect).\nHTML:\n%s", html)
+	}
+}
+
+// =============================================================================
+// Test 2 — Issue #340: IsReconnect fires after a real reconnect (page reload
+// with persisted state). On the second visit the WS-path Mount/OnConnect see
+// state restored from the prior visit, so IsReconnect()=true and the count
+// (which OnConnect increments) accumulates across reloads.
+// =============================================================================
+
+func TestE2E_IsReconnect_ReflectsStateRestoration(t *testing.T) {
+	baseURL, port, shutdown := startLifecycleE2EServer(t)
+	defer shutdown()
+	_ = baseURL
+
+	chromeCtx, cleanup := e2etest.SetupDockerChrome(t, 45*time.Second)
+	defer cleanup()
+	ctx := chromeCtx.Context
+	installConsoleLogger(t, ctx)
+	wsLog := e2etest.RecordWSFrames(ctx)
+
+	chromeURL := e2etest.GetChromeTestURL(port)
+
+	// First visit: HTTP GET + WS connect. State is persisted on Mount, then
+	// restored when the WS connects, so the WS-path OnConnect sees IsReconnect
+	// = true. The DOM settles with im=NO (WS overwrites HTTP's im=YES) and
+	// rc=YES.
+	if err := chromedp.Run(ctx, chromedp.Navigate(chromeURL)); err != nil {
+		t.Fatalf("first navigate: %v", err)
+	}
+	waitForCondition(t, ctx,
+		`document.getElementById('rc').innerText.includes('rc=YES')
+		 && document.getElementById('im').innerText.includes('im=NO')`,
+		5*time.Second,
+		"first WS connect to settle (rc=YES, im=NO)")
+
+	receivedBefore := wsLog.CountByDirection("received")
+
+	// Reload: a fresh HTTP GET re-renders im=YES (initial mount) and rc=YES
+	// (state restored from prior visit). The WS then reconnects and OnConnect
+	// runs again, flipping the DOM back to im=NO rc=YES. We rely on the WS
+	// frame counter (not OnConnect-incremented state, which isn't persisted)
+	// to prove the reconnect round-trip happened.
+	if err := chromedp.Run(ctx, chromedp.Reload()); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	waitForCondition(t, ctx,
+		`document.getElementById('rc').innerText.includes('rc=YES')
+		 && document.getElementById('im').innerText.includes('im=NO')`,
+		10*time.Second,
+		"reload + WS reconnect to settle (rc=YES, im=NO)")
+
+	if got := wsLog.CountByDirection("received") - receivedBefore; got == 0 {
+		wsLog.PrintLast(5)
+		t.Errorf("no new WS frames after reload — client may not have re-dialed")
+	}
+}
+
+// =============================================================================
+// Test 3 — Issue #345: ClearAllFlash from an action wipes every flash entry
+// while leaving the rest of the DOM untouched.
+// =============================================================================
+
+func TestE2E_ClearAllFlash_RemovesAllFlashFromDOM(t *testing.T) {
+	baseURL, port, shutdown := startLifecycleE2EServer(t)
+	defer shutdown()
+	_ = baseURL
+
+	chromeCtx, cleanup := e2etest.SetupDockerChrome(t, 30*time.Second)
+	defer cleanup()
+	ctx := chromeCtx.Context
+	installConsoleLogger(t, ctx)
+	wsLog := e2etest.RecordWSFrames(ctx)
+
+	chromeURL := e2etest.GetChromeTestURL(port)
+
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(chromeURL),
+		chromedp.WaitVisible("#set-flashes", chromedp.ByID),
+	); err != nil {
+		t.Fatalf("navigate: %v", err)
+	}
+
+	// 1. Click "Set flashes" — server sets two flashes. DOM updates over WS.
+	if err := chromedp.Run(ctx, chromedp.Click("#set-flashes", chromedp.ByID)); err != nil {
+		t.Fatalf("click set-flashes: %v", err)
+	}
+	waitForCondition(t, ctx,
+		`document.getElementById('flash-success').innerText.includes('Saved!')
+		 && document.getElementById('flash-info').innerText.includes('Heads up')`,
+		5*time.Second,
+		"both flashes to land in DOM after SetFlashes")
+
+	// 2. Click "Clear all" — invokes ctx.ClearAllFlash. Both flashes vanish.
+	if err := chromedp.Run(ctx, chromedp.Click("#clear-flashes", chromedp.ByID)); err != nil {
+		t.Fatalf("click clear-flashes: %v", err)
+	}
+	waitForCondition(t, ctx,
+		`document.getElementById('flash-success').innerText.trim() === ''
+		 && document.getElementById('flash-info').innerText.trim() === ''`,
+		5*time.Second,
+		"both flashes to clear from DOM after ClearAllFlash")
+
+	// Sanity: ClearAllFlash must NOT touch non-flash state — count must remain.
+	var count string
+	if err := chromedp.Run(ctx, chromedp.Text("#count", &count, chromedp.NodeVisible, chromedp.ByID)); err != nil {
+		t.Fatalf("read count: %v", err)
+	}
+	if !strings.Contains(count, "count=") {
+		t.Errorf("count tag missing after ClearAllFlash — non-flash state was wiped")
+	}
+
+	// WS log: at least one frame round-tripped during the click sequence.
+	if wsLog.CountByDirection("sent") < 2 {
+		wsLog.PrintLast(10)
+		t.Errorf("expected at least 2 WS frames sent (one per click), got %d", wsLog.CountByDirection("sent"))
+	}
+}
+
+// =============================================================================
+// Test 4 — Issue #339: ErrSessionDisconnected via a raw-WS smoke test.
+// The sentinel itself is server-side; the Go integration test
+// TestLocalSession_TriggerActionDisconnectedReturnsError already asserts
+// errors.Is on the sentinel. Here we just confirm the WS happy path doesn't
+// regress after the sentinel-wrapping change.
+// =============================================================================
+
+func TestE2E_ErrSessionDisconnected_HappyPathStillWorks(t *testing.T) {
+	baseURL, _, shutdown := startLifecycleE2EServer(t)
+	defer shutdown()
+
+	wsURL := "ws" + strings.TrimPrefix(baseURL, "http") + "/"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("ws dial: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	if _, _, err := conn.ReadMessage(); err != nil {
+		t.Fatalf("initial frame read: %v", err)
+	}
+
+	msg, _ := json.Marshal(map[string]interface{}{"action": "SetFlashes", "data": map[string]interface{}{}})
+	if err := conn.WriteMessage(websocket.TextMessage, msg); err != nil {
+		t.Fatalf("ws write: %v", err)
+	}
+	if _, _, err := conn.ReadMessage(); err != nil {
+		t.Fatalf("ws read after action: %v", err)
+	}
+}

--- a/e2e/lifecycle_ergonomics_test.go
+++ b/e2e/lifecycle_ergonomics_test.go
@@ -1,12 +1,11 @@
 //go:build browser
 
-// NOTE: this file declares `package e2e_test` (external test package) rather
-// than `package e2e` because the `e2e` package already exposes its own
-// `chromedp.Action`-returning polling helpers — `waitForCondition` in
-// `helpers.go` and `waitForDOM` in `rendering_test.go`. Moving this file in
-// would force renaming the local fatal-test-helper polling loop, and the
-// directory already mixes both package forms (e.g., `livetemplate_core_test.go`
-// is `package e2e_test` too).
+// NOTE: this file declares `package e2e_test` (external test package) to match
+// the convention used by `livetemplate_core_test.go`. The local
+// `requireCondition` helper uses the `require*` prefix (Go testing convention
+// for "fatal on failure") to distinguish it from the `chromedp.Action`-returning
+// `waitForCondition` in `helpers.go` and `waitForDOM` in `rendering_test.go`,
+// which return errors instead of calling `t.Fatalf`.
 package e2e_test
 
 import (
@@ -135,6 +134,10 @@ func startLifecycleE2EServer(t *testing.T) (baseURL string, port int, shutdown f
 	server := &http.Server{Addr: fmt.Sprintf(":%d", p), Handler: mux}
 
 	go func() {
+		// log.Printf (not t.Logf) because calling t.Logf from a goroutine
+		// after the test has finished panics. ListenAndServe errors are rare
+		// in practice, and the stdout log is good enough for the cases that
+		// do happen (port-bind race, etc.).
 		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Printf("server: %v", err)
 		}
@@ -165,13 +168,13 @@ func installConsoleLogger(t *testing.T, ctx context.Context) {
 	})
 }
 
-// waitForCondition polls a JS expression until it returns true or the timeout
+// requireCondition polls a JS expression until it returns true or the timeout
 // elapses. Used for "DOM should reflect X after WS round-trip" assertions.
 //
 // A cancelled chromedp context (e.g. browser crash, Docker shutdown) is fatal
 // immediately — without that early return the loop would silently treat
 // context.Canceled as "condition not yet true" and report a misleading timeout.
-func waitForCondition(t *testing.T, ctx context.Context, jsExpr string, timeout time.Duration, why string) {
+func requireCondition(t *testing.T, ctx context.Context, jsExpr string, timeout time.Duration, why string) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
@@ -256,7 +259,7 @@ func TestE2E_IsReconnect_ReflectsStateRestoration(t *testing.T) {
 	if err := chromedp.Run(ctx, chromedp.Navigate(chromeURL)); err != nil {
 		t.Fatalf("first navigate: %v", err)
 	}
-	waitForCondition(t, ctx,
+	requireCondition(t, ctx,
 		`document.getElementById('rc').innerText.includes('rc=YES')
 		 && document.getElementById('im').innerText.includes('im=NO')`,
 		5*time.Second,
@@ -273,7 +276,7 @@ func TestE2E_IsReconnect_ReflectsStateRestoration(t *testing.T) {
 	if err := chromedp.Run(ctx, chromedp.Reload()); err != nil {
 		t.Fatalf("reload: %v", err)
 	}
-	waitForCondition(t, ctx,
+	requireCondition(t, ctx,
 		`document.getElementById('rc').innerText.includes('rc=YES')
 		 && document.getElementById('im').innerText.includes('im=NO')`,
 		10*time.Second,
@@ -313,7 +316,7 @@ func TestE2E_ClearAllFlash_RemovesAllFlashFromDOM(t *testing.T) {
 	if err := chromedp.Run(ctx, chromedp.Click("#set-flashes", chromedp.ByID)); err != nil {
 		t.Fatalf("click set-flashes: %v", err)
 	}
-	waitForCondition(t, ctx,
+	requireCondition(t, ctx,
 		`document.getElementById('flash-success').innerText.includes('Saved!')
 		 && document.getElementById('flash-info').innerText.includes('Heads up')`,
 		5*time.Second,
@@ -323,7 +326,7 @@ func TestE2E_ClearAllFlash_RemovesAllFlashFromDOM(t *testing.T) {
 	if err := chromedp.Run(ctx, chromedp.Click("#clear-flashes", chromedp.ByID)); err != nil {
 		t.Fatalf("click clear-flashes: %v", err)
 	}
-	waitForCondition(t, ctx,
+	requireCondition(t, ctx,
 		`document.getElementById('flash-success').innerText.trim() === ''
 		 && document.getElementById('flash-info').innerText.trim() === ''`,
 		5*time.Second,
@@ -367,6 +370,12 @@ func TestE2E_WS_HappyPathRegressionAfterSentinelWrap(t *testing.T) {
 	baseURL, _, shutdown := startLifecycleE2EServer(t)
 	defer shutdown()
 
+	// Dial WS directly without a prior HTTP GET. livetemplate accepts a raw
+	// WS-only connect and initializes a fresh session group with no persisted
+	// state — i.e., this exercises the new-connect path (vs. the
+	// HTTP-then-WS-reconnect path that Test 2 covers). If livetemplate ever
+	// requires a session cookie or prior HTTP handshake, this test will break
+	// on the dial.
 	wsURL := "ws" + strings.TrimPrefix(baseURL, "http") + "/"
 	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
 	if err != nil {

--- a/e2e/lifecycle_ergonomics_test.go
+++ b/e2e/lifecycle_ergonomics_test.go
@@ -1,5 +1,12 @@
 //go:build browser
 
+// NOTE: this file declares `package e2e_test` (external test package) rather
+// than `package e2e` because the `e2e` package already contains a different
+// `waitForCondition` helper (in `helpers.go`) and a `waitForCondition` helper (in
+// `rendering_test.go`) with chromedp.Action signatures. Moving this file in
+// would require renaming the fatal-test-helper polling loop, and the directory
+// already mixes both package forms (e.g., `livetemplate_core_test.go` is
+// `package e2e_test` too).
 package e2e_test
 
 import (
@@ -21,12 +28,15 @@ import (
 )
 
 // =============================================================================
-// E2E coverage for the lifecycle-ergonomics batch (#339, #340, #341, #345).
+// E2E coverage for the browser-observable parts of the lifecycle-ergonomics
+// batch: #339 (ErrSessionDisconnected), #340 (IsInitialMount / IsReconnect),
+// #345 (ClearAllFlash). Issue #341 (validateLifecycleSignatures warn-at-boot)
+// is server-startup-time, not browser-observable, and is covered by the
+// upstream livetemplate unit tests.
 //
-// Verifies the browser-observable behavior end-to-end against a real Chromium
-// and a real livetemplate http.Handler. Per CLAUDE.md (global): chromedp e2e
-// tests surface (1) browser console, (2) server logs, (3) websocket messages,
-// (4) rendered HTML.
+// Verifies behavior end-to-end against a real Chromium and a real livetemplate
+// http.Handler. Per CLAUDE.md (global): chromedp e2e tests surface (1) browser
+// console, (2) server logs, (3) websocket messages, (4) rendered HTML.
 //
 // Important semantic note observed during test development:
 //
@@ -249,9 +259,10 @@ func TestE2E_IsReconnect_ReflectsStateRestoration(t *testing.T) {
 
 	// Reload: a fresh HTTP GET re-renders im=YES (initial mount) and rc=YES
 	// (state restored from prior visit). The WS then reconnects and OnConnect
-	// runs again, flipping the DOM back to im=NO rc=YES. We rely on the WS
-	// frame counter (not OnConnect-incremented state, which isn't persisted)
-	// to prove the reconnect round-trip happened.
+	// runs again, flipping the DOM back to im=NO rc=YES. We assert the WS
+	// frame counter advanced (a direct, unambiguous "re-dialed" signal) rather
+	// than reasoning about post-reload count values, which race with the
+	// in-flight WS connect.
 	if err := chromedp.Run(ctx, chromedp.Reload()); err != nil {
 		t.Fatalf("reload: %v", err)
 	}
@@ -311,13 +322,16 @@ func TestE2E_ClearAllFlash_RemovesAllFlashFromDOM(t *testing.T) {
 		5*time.Second,
 		"both flashes to clear from DOM after ClearAllFlash")
 
-	// Sanity: ClearAllFlash must NOT touch non-flash state — count must remain.
+	// Sanity: ClearAllFlash must NOT touch non-flash state. OnConnect's
+	// `state.Count++` has run at least once by now, so count must be ≥ 1 —
+	// asserting "count=0" would catch a regression where ClearAllFlash zeroed
+	// numeric state instead of just flash keys.
 	var count string
 	if err := chromedp.Run(ctx, chromedp.Text("#count", &count, chromedp.NodeVisible, chromedp.ByID)); err != nil {
 		t.Fatalf("read count: %v", err)
 	}
-	if !strings.Contains(count, "count=") {
-		t.Errorf("count tag missing after ClearAllFlash — non-flash state was wiped")
+	if !strings.Contains(count, "count=") || count == "count=0" {
+		t.Errorf("count tag missing or zeroed after ClearAllFlash — non-flash state was wiped (got %q)", count)
 	}
 
 	// WS log: at least one frame round-tripped during the click sequence.
@@ -351,6 +365,7 @@ func TestE2E_ErrSessionDisconnected_HappyPathStillWorks(t *testing.T) {
 		t.Fatalf("initial frame read: %v", err)
 	}
 
+	_ = conn.SetWriteDeadline(time.Now().Add(3 * time.Second))
 	msg, _ := json.Marshal(map[string]interface{}{"action": "SetFlashes", "data": map[string]interface{}{}})
 	if err := conn.WriteMessage(websocket.TextMessage, msg); err != nil {
 		t.Fatalf("ws write: %v", err)

--- a/e2e/lifecycle_ergonomics_test.go
+++ b/e2e/lifecycle_ergonomics_test.go
@@ -157,13 +157,21 @@ func installConsoleLogger(t *testing.T, ctx context.Context) {
 
 // waitForCondition polls a JS expression until it returns true or the timeout
 // elapses. Used for "DOM should reflect X after WS round-trip" assertions.
+//
+// A cancelled chromedp context (e.g. browser crash, Docker shutdown) is fatal
+// immediately — without that early return the loop would silently treat
+// context.Canceled as "condition not yet true" and report a misleading timeout.
 func waitForCondition(t *testing.T, ctx context.Context, jsExpr string, timeout time.Duration, why string) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		var ok bool
-		if err := chromedp.Run(ctx, chromedp.Evaluate(jsExpr, &ok)); err == nil && ok {
+		err := chromedp.Run(ctx, chromedp.Evaluate(jsExpr, &ok))
+		if err == nil && ok {
 			return
+		}
+		if ctx.Err() != nil {
+			t.Fatalf("chromedp context cancelled waiting for %s: %v", why, ctx.Err())
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
@@ -213,9 +221,8 @@ func TestE2E_IsInitialMount_RendersInInitialHTML(t *testing.T) {
 // =============================================================================
 
 func TestE2E_IsReconnect_ReflectsStateRestoration(t *testing.T) {
-	baseURL, port, shutdown := startLifecycleE2EServer(t)
+	_, port, shutdown := startLifecycleE2EServer(t)
 	defer shutdown()
-	_ = baseURL
 
 	chromeCtx, cleanup := e2etest.SetupDockerChrome(t, 45*time.Second)
 	defer cleanup()
@@ -266,9 +273,8 @@ func TestE2E_IsReconnect_ReflectsStateRestoration(t *testing.T) {
 // =============================================================================
 
 func TestE2E_ClearAllFlash_RemovesAllFlashFromDOM(t *testing.T) {
-	baseURL, port, shutdown := startLifecycleE2EServer(t)
+	_, port, shutdown := startLifecycleE2EServer(t)
 	defer shutdown()
-	_ = baseURL
 
 	chromeCtx, cleanup := e2etest.SetupDockerChrome(t, 30*time.Second)
 	defer cleanup()

--- a/e2e/lifecycle_ergonomics_test.go
+++ b/e2e/lifecycle_ergonomics_test.go
@@ -206,7 +206,12 @@ func TestE2E_IsInitialMount_RendersInInitialHTML(t *testing.T) {
 	// 1. The server-rendered HTML — captured BEFORE any WS connects — must
 	// reflect IsInitialMount()=true. http.Get takes no WS round-trip, so
 	// this isolates the HTTP-path Mount classification.
-	resp, err := http.Get(baseURL)
+	//
+	// Use an explicit 5s client timeout instead of http.DefaultClient, which
+	// has no timeout — a slow CI runner could otherwise hang until the test
+	// binary's -timeout fires, making the failure diagnostic-poor.
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Get(baseURL)
 	if err != nil {
 		t.Fatalf("http.Get: %v", err)
 	}

--- a/e2e/lifecycle_ergonomics_test.go
+++ b/e2e/lifecycle_ergonomics_test.go
@@ -379,15 +379,23 @@ func TestE2E_WS_HappyPathRegressionAfterSentinelWrap(t *testing.T) {
 	if err := conn.SetWriteDeadline(time.Now().Add(3 * time.Second)); err != nil {
 		t.Fatalf("set write deadline: %v", err)
 	}
-	msg, _ := json.Marshal(map[string]interface{}{"action": "SetFlashes", "data": map[string]interface{}{}})
+	msg, err := json.Marshal(map[string]interface{}{"action": "SetFlashes", "data": map[string]interface{}{}})
+	if err != nil {
+		t.Fatalf("marshal action payload: %v", err)
+	}
 	if err := conn.WriteMessage(websocket.TextMessage, msg); err != nil {
 		t.Fatalf("ws write: %v", err)
 	}
-	// Refresh the read deadline — the one set before the first ReadMessage has
-	// been consumed by the write round-trip and may be near-expired on slow CI.
+	// Refresh the read deadline — wall-clock time has elapsed during the write
+	// round-trip, so the remaining time on the deadline set before the first
+	// ReadMessage may be too short for a slow CI runner.
 	if err := conn.SetReadDeadline(time.Now().Add(3 * time.Second)); err != nil {
 		t.Fatalf("refresh read deadline: %v", err)
 	}
+	// This read only confirms the server replied to the action — we don't
+	// inspect frame contents because the sentinel's behavioral surface is
+	// covered by livetemplate's unit tests. The test name's "Regression"
+	// part is literal: prove the WS happy path still works post-wrap.
 	if _, _, err := conn.ReadMessage(); err != nil {
 		t.Fatalf("ws read after action: %v", err)
 	}

--- a/e2e/lifecycle_ergonomics_test.go
+++ b/e2e/lifecycle_ergonomics_test.go
@@ -334,22 +334,29 @@ func TestE2E_ClearAllFlash_RemovesAllFlashFromDOM(t *testing.T) {
 		t.Errorf("count tag missing or zeroed after ClearAllFlash — non-flash state was wiped (got %q)", count)
 	}
 
-	// WS log: at least one frame round-tripped during the click sequence.
-	if wsLog.CountByDirection("sent") < 2 {
+	// WS log: at least one frame round-tripped each way during the click sequence.
+	// Sent: one frame per click (SetFlashes, ClearFlashes). Received: server's
+	// state-update response for each action.
+	if sent := wsLog.CountByDirection("sent"); sent < 2 {
 		wsLog.PrintLast(10)
-		t.Errorf("expected at least 2 WS frames sent (one per click), got %d", wsLog.CountByDirection("sent"))
+		t.Errorf("expected at least 2 WS frames sent (one per click), got %d", sent)
+	}
+	if received := wsLog.CountByDirection("received"); received < 2 {
+		wsLog.PrintLast(10)
+		t.Errorf("expected at least 2 WS frames received (one response per click), got %d", received)
 	}
 }
 
 // =============================================================================
-// Test 4 — Issue #339: ErrSessionDisconnected via a raw-WS smoke test.
-// The sentinel itself is server-side; the Go integration test
-// TestLocalSession_TriggerActionDisconnectedReturnsError already asserts
-// errors.Is on the sentinel. Here we just confirm the WS happy path doesn't
-// regress after the sentinel-wrapping change.
+// Test 4 — Issue #339: regression check that wrapping the "no connected
+// sessions" error with the ErrSessionDisconnected sentinel didn't break the
+// WS happy path. The sentinel itself (and its errors.Is wiring) is asserted
+// in livetemplate's TestLocalSession_TriggerActionDisconnectedReturnsError;
+// this test only verifies that a fresh WS connect + action round-trip still
+// works post-change.
 // =============================================================================
 
-func TestE2E_ErrSessionDisconnected_HappyPathStillWorks(t *testing.T) {
+func TestE2E_WS_HappyPathRegressionAfterSentinelWrap(t *testing.T) {
 	baseURL, _, shutdown := startLifecycleE2EServer(t)
 	defer shutdown()
 
@@ -360,12 +367,16 @@ func TestE2E_ErrSessionDisconnected_HappyPathStillWorks(t *testing.T) {
 	}
 	defer func() { _ = conn.Close() }()
 
-	_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	if err := conn.SetReadDeadline(time.Now().Add(3 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
 	if _, _, err := conn.ReadMessage(); err != nil {
 		t.Fatalf("initial frame read: %v", err)
 	}
 
-	_ = conn.SetWriteDeadline(time.Now().Add(3 * time.Second))
+	if err := conn.SetWriteDeadline(time.Now().Add(3 * time.Second)); err != nil {
+		t.Fatalf("set write deadline: %v", err)
+	}
 	msg, _ := json.Marshal(map[string]interface{}{"action": "SetFlashes", "data": map[string]interface{}{}})
 	if err := conn.WriteMessage(websocket.TextMessage, msg); err != nil {
 		t.Fatalf("ws write: %v", err)

--- a/e2e/lifecycle_ergonomics_test.go
+++ b/e2e/lifecycle_ergonomics_test.go
@@ -1,12 +1,12 @@
 //go:build browser
 
 // NOTE: this file declares `package e2e_test` (external test package) rather
-// than `package e2e` because the `e2e` package already contains a different
-// `waitForCondition` helper (in `helpers.go`) and a `waitForCondition` helper (in
-// `rendering_test.go`) with chromedp.Action signatures. Moving this file in
-// would require renaming the fatal-test-helper polling loop, and the directory
-// already mixes both package forms (e.g., `livetemplate_core_test.go` is
-// `package e2e_test` too).
+// than `package e2e` because the `e2e` package already exposes its own
+// `chromedp.Action`-returning polling helpers — `waitForCondition` in
+// `helpers.go` and `waitForDOM` in `rendering_test.go`. Moving this file in
+// would force renaming the local fatal-test-helper polling loop, and the
+// directory already mixes both package forms (e.g., `livetemplate_core_test.go`
+// is `package e2e_test` too).
 package e2e_test
 
 import (
@@ -183,7 +183,9 @@ func waitForCondition(t *testing.T, ctx context.Context, jsExpr string, timeout 
 		if ctx.Err() != nil {
 			t.Fatalf("chromedp context cancelled waiting for %s: %v", why, ctx.Err())
 		}
-		time.Sleep(50 * time.Millisecond)
+		// 100ms matches lvt/testing's WaitFor convention — chosen there for
+		// stability and to avoid CPU thrashing on slow CI runners.
+		time.Sleep(100 * time.Millisecond)
 	}
 	var html string
 	_ = chromedp.Run(ctx, chromedp.OuterHTML("body", &html, chromedp.ByQuery))
@@ -380,6 +382,11 @@ func TestE2E_WS_HappyPathRegressionAfterSentinelWrap(t *testing.T) {
 	msg, _ := json.Marshal(map[string]interface{}{"action": "SetFlashes", "data": map[string]interface{}{}})
 	if err := conn.WriteMessage(websocket.TextMessage, msg); err != nil {
 		t.Fatalf("ws write: %v", err)
+	}
+	// Refresh the read deadline — the one set before the first ReadMessage has
+	// been consumed by the write round-trip and may be near-expired on slow CI.
+	if err := conn.SetReadDeadline(time.Now().Add(3 * time.Second)); err != nil {
+		t.Fatalf("refresh read deadline: %v", err)
 	}
 	if _, _, err := conn.ReadMessage(); err != nil {
 		t.Fatalf("ws read after action: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/livetemplate/lvt
 
 go 1.26.0
 
-require github.com/livetemplate/livetemplate v0.9.0
+require github.com/livetemplate/livetemplate v0.9.1
 
 replace github.com/livetemplate/lvt/components => ./components
 

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kUL
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/livetemplate/livetemplate v0.9.0 h1:6vHNNpZLIY4gO08/Gth3vr1F3A3ANwSKTQvfuy1I8js=
-github.com/livetemplate/livetemplate v0.9.0/go.mod h1:GMvZKyPUq8LSGfgD3pftKOHa6v+I+RDYyff2mNjeAYs=
+github.com/livetemplate/livetemplate v0.9.1 h1:cTPZ9IVOej4CcpGYXjFd4uDVsAnQPiq3YsVITqKLN0s=
+github.com/livetemplate/livetemplate v0.9.1/go.mod h1:GMvZKyPUq8LSGfgD3pftKOHa6v+I+RDYyff2mNjeAYs=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=


### PR DESCRIPTION
## Summary

Adds end-to-end browser tests covering the four lifecycle/Context/Session helpers landed in [livetemplate#408](https://github.com/livetemplate/livetemplate/pull/408) and released as [v0.9.1](https://github.com/livetemplate/livetemplate/releases/tag/v0.9.1).

This PR was authored alongside livetemplate#408 itself — the tests verified the new API green during the feature PR's review cycle (via a temporary `go.work` swap), but couldn't land in lvt until livetemplate had a *released* version exposing the symbols. v0.9.1 makes them public, so this PR catches up.

## What's covered

| Issue | Symbol | Test |
|---|---|---|
| livetemplate#340 | `Context.IsInitialMount()` | `TestE2E_IsInitialMount_RendersInInitialHTML` — asserts the server-rendered HTML on an HTTP GET contains `im=YES` *before* any WS connects. Uses `http.Get` (not chromedp) to isolate the HTTP-path Mount classification. |
| livetemplate#340 | `Context.IsReconnect()` | `TestE2E_IsReconnect_ReflectsStateRestoration` — navigates, reloads, and asserts the DOM settles to `rc=YES, im=NO` after the WS reconnect with state restored from the prior visit. |
| livetemplate#345 | `Context.ClearAllFlash()` | `TestE2E_ClearAllFlash_RemovesAllFlashFromDOM` — clicks Set/Clear and asserts both flashes vanish from the DOM while non-flash state (`count`) is untouched. |
| livetemplate#339 | `ErrSessionDisconnected` | `TestE2E_WS_HappyPathRegressionAfterSentinelWrap` — raw gorilla WS dial + action round-trip, smoke-testing that the sentinel-wrap didn't regress the happy path. (The sentinel itself is asserted via `errors.Is` in livetemplate's unit tests.) |

## Semantic note worth knowing

In the normal browser flow — HTTP GET → server-renders HTML → WS connects — the framework persists state at the end of the HTTP Mount, so when the WS connects, `restorePersistedState` returns ok and `IsReconnect()` is `true` inside the WS-path Mount/OnConnect. That's why these tests use `http.Get` (not chromedp DOM read) for the `IsInitialMount=true` assertion: by the time the WS has connected, OnConnect has overwritten the DOM to `im=NO`. This is documented inline in the test file's header comment and is the subject of livetemplate#409 ("Refine IsReconnect semantics") — i.e., the test pins current behavior; the design follow-up is tracked separately.

## Per CLAUDE.md global e2e test requirements

These tests surface the four mandated debugging signals when they fail:
1. **Browser console** — `installConsoleLogger` pipes `console.*` calls to `t.Logf`
2. **Server logs** — slog output goes to the standard test logger
3. **WebSocket messages** — `e2etest.RecordWSFrames` captures direction-tagged frames; tests print last N on failure
4. **Rendered HTML** — `waitForCondition` dumps full `body` outerHTML on timeout

## Test plan

- [x] `GOWORK=off go vet -tags browser ./e2e/...` — clean
- [x] `GOWORK=off go test ./... -timeout 300s` — full lvt suite green (after installing `sqlc` for the pre-existing integration tests)
- [x] `GOWORK=off go test -tags browser -timeout 300s -run 'TestE2E_.*' ./e2e/` — all four lifecycle tests pass (combined ~4s wall time)
- [x] `golangci-lint run --default=none --enable=errcheck,unused,staticcheck,ineffassign --build-tags=browser ./e2e/...` — zero new lint issues in the new file (44 pre-existing issues in unrelated files are out of scope)

## Out of scope

- Fixing the 44 pre-existing lint issues in lvt's `e2e/` package (`chrome_pool.go`, `rendering_test.go`, `shared_test.go`, …). Worth a follow-up PR.
- Fixing `scripts/pre-commit.sh` which uses golangci-lint v1's `--disable-all` flag (removed in v2 in favor of `--default=none`). Also a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
