### PR TITLE
test(e2e): V14 Tier-2 chromedp — topic ACL error envelope + WS keep-open (livetemplate#415) — DRAFT, Phase-5-resolved

### DIFF
--- a/e2e/topic_acl_error_envelope_v14_test.go
+++ b/e2e/topic_acl_error_envelope_v14_test.go
@@ -100,17 +100,34 @@ document.addEventListener('lvt:error', function (e) { window.__lvtErrors.push(e.
 // CDN and would not contain the unreleased lvt:error branch — and whose 1h
 // disk cache can shadow LVT_CLIENT_CDN_URL anyway). Phase 5/6 reverts this to
 // ServeClientLibrary after @livetemplate/client publishes.
+//
+// Bundle resolution order — both honor the cross-repo Phase-4 setup the
+// proposal's release order assumes:
+//   1. LVT_CLIENT_BUNDLE_PATH env var (explicit override)
+//   2. Repo-relative convention path (assumes both worktrees live at
+//      <repo>/.worktrees/broadcast-redesign-phase-4 — the standing rule)
+//
+// If neither resolves, t.Skip — this test is gated on the Phase-4 cross-repo
+// setup. NOT a t.Fatalf: failing the whole -tags=browser run for a
+// contributor not set up for V14 / Phase 4 would be a hostile default, and
+// the proposal's release order explicitly says this e2e is intentionally
+// not CI-runnable until Phase 5's pin bump. The skip message points at the
+// learnings doc for setup.
 func serveLocalPhase4ClientBundle(t *testing.T) http.HandlerFunc {
 	t.Helper()
+	const repoRelativeDefault = "../../../../client/.worktrees/broadcast-redesign-phase-4/dist/livetemplate-client.browser.js"
 	path := os.Getenv("LVT_CLIENT_BUNDLE_PATH")
 	if path == "" {
-		path = "/home/adnaan/code/livetemplate/client/.worktrees/broadcast-redesign-phase-4/dist/livetemplate-client.browser.js"
+		path = repoRelativeDefault
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {
-		t.Fatalf("V14 e2e needs the Phase-4 client bundle. Set LVT_CLIENT_BUNDLE_PATH "+
-			"or build it: (cd client/.worktrees/broadcast-redesign-phase-4 && npm run build). "+
-			"read %q: %v", path, err)
+		t.Skipf("V14 e2e gated on the Phase-4 client bundle (cross-repo, not CI-runnable "+
+			"until livetemplate Phase 5's pin bump — see docs/proposals/broadcast-action-"+
+			"redesign-proposal/learnings/phase-4.md). Set LVT_CLIENT_BUNDLE_PATH or build "+
+			"the bundle at the repo-relative default %q: (cd <umbrella>/client/.worktrees/"+
+			"broadcast-redesign-phase-4 && npm run build). read %q: %v",
+			repoRelativeDefault, path, err)
 	}
 	return func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/javascript")
@@ -233,7 +250,22 @@ func TestE2E_V14_TopicACLDeniedEmitsLvtErrorAndKeepsWSOpen(t *testing.T) {
 		"lvt:error CustomEvent {code:topic_forbidden, topic:private/admin}",
 	)
 
-	// (b) The WS is OPEN AND FUNCTIONAL: a real action round-trips and
+	// (b) Verify the server actually took the Phase-4 keep-open code path —
+	// not just that the client happened to stay connected. The server-side
+	// WARN log is the load-bearing signal that mount.go's *TopicForbiddenError
+	// branch (Option B fall-through) ran instead of the pre-Phase-4 return.
+	// Guards against silent regressions where the log message changes or the
+	// WARN is removed without the corresponding behavior change.
+	if !serverLogger.HasLog("connection kept open") {
+		dump()
+		t.Fatal("expected server to log the Phase-4 keep-open WARN " +
+			"('Mount Subscribe denied by topic ACL; surfaced to client, " +
+			"connection kept open') after ACL denial — the WARN is the proof " +
+			"the server took the keep-open code path, not just that the " +
+			"client happened to stay connected")
+	}
+
+	// (c) The WS is OPEN AND FUNCTIONAL: a real action round-trips and
 	// re-renders. If the server had closed the socket (pre-Phase-4 behavior),
 	// the client's auto-reconnect would re-Mount → re-deny → loop, and #pong
 	// would never become PONG over a live WS.

--- a/e2e/topic_acl_error_envelope_v14_test.go
+++ b/e2e/topic_acl_error_envelope_v14_test.go
@@ -26,7 +26,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"log/slog"
 	"net/http"
 	"os"
@@ -157,8 +156,11 @@ func startV14ACLServer(t *testing.T) (port int, shutdown func()) {
 	}
 	server := &http.Server{Addr: fmt.Sprintf(":%d", p), Handler: mux}
 	go func() {
+		// slog (not log.Printf) so a startup error lands in the
+		// serverLogger-captured stream the test surfaces on failure,
+		// not in the default process stderr.
 		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Printf("v14 server: %v", err)
+			slog.Error("v14 server ListenAndServe failed", slog.Any("error", err))
 		}
 	}()
 
@@ -166,7 +168,12 @@ func startV14ACLServer(t *testing.T) (port int, shutdown func()) {
 	return p, func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		_ = server.Shutdown(ctx)
+		// Log shutdown failures so flaky teardown on slow CI is diagnosable
+		// once Phase 5 makes this CI-runnable (currently captured via
+		// serverLogger / surfaced on test failure).
+		if err := server.Shutdown(ctx); err != nil {
+			slog.Error("v14 server Shutdown failed", slog.Any("error", err))
+		}
 	}
 }
 

--- a/e2e/topic_acl_error_envelope_v14_test.go
+++ b/e2e/topic_acl_error_envelope_v14_test.go
@@ -178,6 +178,12 @@ func startV14ACLServer(t *testing.T) (port int, shutdown func()) {
 }
 
 func TestE2E_V14_TopicACLDeniedEmitsLvtErrorAndKeepsWSOpen(t *testing.T) {
+	// Not parallel: this test mutates the process-global slog.Default. Other
+	// tests in this package that also touch slog.Default (or that observe
+	// livetemplate's internal logging via the same global) would race if
+	// this ran via t.Parallel(). Sibling browser e2es (e.g.
+	// lifecycle_ergonomics_test.go) follow the same non-parallel convention.
+
 	// Artifact 2/4 — server logs. livetemplate logs via the global slog
 	// default (incl. the new "Mount Subscribe denied … connection kept open"
 	// WARN). Tee into a captured buffer; restore the default in Cleanup
@@ -265,8 +271,15 @@ func TestE2E_V14_TopicACLDeniedEmitsLvtErrorAndKeepsWSOpen(t *testing.T) {
 	// not just that the client happened to stay connected. The server-side
 	// WARN log is the load-bearing signal that mount.go's *TopicForbiddenError
 	// branch (Option B fall-through) ran instead of the pre-Phase-4 return.
-	// Guards against silent regressions where the log message changes or the
-	// WARN is removed without the corresponding behavior change.
+	// Guards against silent regressions where the WARN is removed without the
+	// corresponding behavior change.
+	//
+	// Coupling: substring of the WARN message in livetemplate's
+	// mount.go (grep anchor: `slog.Warn("Mount Subscribe denied by topic ACL`).
+	// If that prose is reworded, update both here and the
+	// livetemplate-side log call together. A future hardening would be to
+	// switch the server WARN to a structured `slog.String("event", "<key>")`
+	// and assert on the structured key — tracked for Phase 5/6.
 	if !serverLogger.HasLog("connection kept open") {
 		dump()
 		t.Fatal("expected server to log the Phase-4 keep-open WARN " +

--- a/e2e/topic_acl_error_envelope_v14_test.go
+++ b/e2e/topic_acl_error_envelope_v14_test.go
@@ -1,0 +1,261 @@
+//go:build browser
+
+// V14 (Tier-2, user-visible leg) — broadcast-action-redesign #415, Phase 4.
+//
+// An ACL-denied ctx.Subscribe in the WS-connect Mount must, end-to-end in a
+// real browser: (a) surface as an `lvt:error` CustomEvent { code, topic } on
+// the wrapper, and (b) leave the WebSocket OPEN AND FUNCTIONAL (Phase 4's
+// keep-open finalization of the decision Phase 1 deferred). The {code,topic}
+// asserted here is byte-for-byte the server-emitted contract
+// (livetemplate topic_runtime.go topicErrorEnvelope) and the client logic-leg
+// jest contract (../client tests/topic-error-envelope.test.ts).
+//
+// CROSS-REPO / RELEASE ORDER: this file is built against the unreleased
+// Phase-0..4 livetemplate via the committed `replace` in go.mod (pointing at
+// the livetemplate Phase-4 worktree). Until livetemplate ships and Phase 5
+// resolves that replace into a real version pin, the lvt Phase-4 branch is
+// intentionally NOT independently mergeable / CI-runnable — this is the
+// proposal's documented "lvt e2e gates last (consumes both)" release order,
+// recorded in docs learnings/phase-4.md, NOT a skipped test. It is run green
+// locally against the worktree build + locally-built client bundle. Phase 5/6
+// swaps serveLocalPhase4ClientBundle back to e2etest.ServeClientLibrary once
+// @livetemplate/client is published.
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"log/slog"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/chromedp/chromedp"
+	"github.com/livetemplate/livetemplate"
+	e2etest "github.com/livetemplate/lvt/testing"
+)
+
+type v14ACLState struct{ Pong string }
+
+type v14ACLController struct{}
+
+// Mount subscribes a developer topic the ACL denies and propagates the error
+// (the canonical `return s, err` real apps use), exercising the WS-connect
+// Mount-failure path that emits the topic_forbidden envelope.
+//
+// IsInitialMount guard: Mount runs on every HTTP request AND WebSocket
+// connect (livetemplate CLAUDE.md "Mount() guard pattern"). On the initial
+// HTTP GET (page render), a denied ctx.Subscribe surfaces as HTTP 500
+// (mount.go HTTP-GET path; phase-1.md "HTTP-GET ACL-denial → HTTP 500" — a
+// pre-existing condition unchanged by Phase 4). If we didn't skip the
+// Subscribe on the GET, the page would 500, client.js would never load, and
+// there'd be no WS for V14 to exercise. V14's pinned scenario is exactly the
+// WS-connect Mount denied-Subscribe (envelope + keep-open), so the guard
+// scopes the denial to that path — which is also V14's exact spec wording.
+func (c *v14ACLController) Mount(s v14ACLState, ctx *livetemplate.Context) (v14ACLState, error) {
+	if ctx.IsInitialMount() {
+		return s, nil
+	}
+	if err := ctx.Subscribe("private/admin"); err != nil {
+		return s, err
+	}
+	return s, nil
+}
+
+// Ping is the post-envelope usability probe: a successful action round-trip
+// re-renders #pong, proving the socket stayed FUNCTIONAL — not merely
+// "not closed in the first N ms".
+func (c *v14ACLController) Ping(s v14ACLState, _ *livetemplate.Context) (v14ACLState, error) {
+	s.Pong = "PONG"
+	return s, nil
+}
+
+// The <head> script installs a CAPTURE-phase document listener BEFORE
+// client.js loads and before the WS connects. The client dispatches
+// `lvt:error` on the wrapper as a non-bubbling CustomEvent; a capture-phase
+// document listener still observes it (capture traverses window→target
+// regardless of `bubbles`), which removes the listener-vs-first-frame race
+// without instrumenting the client.
+const v14ACLTemplate = `<!DOCTYPE html>
+<html>
+<head>
+<title>V14 topic ACL error envelope</title>
+<script>
+window.__lvtErrors = [];
+document.addEventListener('lvt:error', function (e) { window.__lvtErrors.push(e.detail); }, true);
+</script>
+</head>
+<body>
+  <div id="pong">{{.Pong}}</div>
+  <button id="ping" lvt-on:click="Ping">Ping</button>
+  <script src="/client.js"></script>
+</body>
+</html>`
+
+// serveLocalPhase4ClientBundle serves the locally-built Phase-4 client bundle
+// (NOT e2etest.ServeClientLibrary, which fetches the published client from a
+// CDN and would not contain the unreleased lvt:error branch — and whose 1h
+// disk cache can shadow LVT_CLIENT_CDN_URL anyway). Phase 5/6 reverts this to
+// ServeClientLibrary after @livetemplate/client publishes.
+func serveLocalPhase4ClientBundle(t *testing.T) http.HandlerFunc {
+	t.Helper()
+	path := os.Getenv("LVT_CLIENT_BUNDLE_PATH")
+	if path == "" {
+		path = "/home/adnaan/code/livetemplate/client/.worktrees/broadcast-redesign-phase-4/dist/livetemplate-client.browser.js"
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("V14 e2e needs the Phase-4 client bundle. Set LVT_CLIENT_BUNDLE_PATH "+
+			"or build it: (cd client/.worktrees/broadcast-redesign-phase-4 && npm run build). "+
+			"read %q: %v", path, err)
+	}
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/javascript")
+		_, _ = w.Write(data)
+	}
+}
+
+func startV14ACLServer(t *testing.T) (port int, shutdown func()) {
+	t.Helper()
+
+	tmpl := livetemplate.Must(livetemplate.New("v14-acl-e2e",
+		livetemplate.WithTopicACL(func(topic, _ string, _ *http.Request) (bool, error) {
+			return topic != "private/admin", nil
+		}),
+	))
+	if _, err := tmpl.Parse(v14ACLTemplate); err != nil {
+		t.Fatalf("parse template: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/", tmpl.Handle(&v14ACLController{}, livetemplate.AsState(&v14ACLState{})))
+	mux.HandleFunc("/client.js", serveLocalPhase4ClientBundle(t))
+
+	p, err := e2etest.GetFreePort()
+	if err != nil {
+		t.Fatalf("free port: %v", err)
+	}
+	server := &http.Server{Addr: fmt.Sprintf(":%d", p), Handler: mux}
+	go func() {
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Printf("v14 server: %v", err)
+		}
+	}()
+
+	e2etest.WaitForServer(t, fmt.Sprintf("http://localhost:%d", p), 10*time.Second)
+	return p, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = server.Shutdown(ctx)
+	}
+}
+
+func TestE2E_V14_TopicACLDeniedEmitsLvtErrorAndKeepsWSOpen(t *testing.T) {
+	// Artifact 2/4 — server logs. livetemplate logs via the global slog
+	// default (incl. the new "Mount Subscribe denied … connection kept open"
+	// WARN). Tee into a captured buffer; restore the default in Cleanup
+	// (slog.SetDefault is process-global and the default persists across
+	// tests in this package).
+	serverLogger := e2etest.NewServerLogger()
+	serverLogger.Start()
+	defer serverLogger.Stop()
+	prevSlog := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(
+		io.MultiWriter(os.Stderr, serverLogger.Writer()),
+		&slog.HandlerOptions{Level: slog.LevelDebug},
+	)))
+	t.Cleanup(func() { slog.SetDefault(prevSlog) })
+
+	port, shutdown := startV14ACLServer(t)
+	defer shutdown()
+
+	chromeCtx, cleanup := e2etest.SetupDockerChrome(t, 60*time.Second)
+	defer cleanup()
+	ctx := chromeCtx.Context
+
+	installConsoleLogger(t, ctx)         // artifact 1/4 — browser console (streamed live)
+	wsLog := e2etest.RecordWSFrames(ctx) // artifact 3/4 — WS frames
+
+	// dump surfaces all four artifacts on failure while the chrome ctx is
+	// still alive (defer cleanup() cancels it before t.Cleanup runs, so HTML
+	// must be captured here, not in Cleanup). Console is already streamed.
+	dump := func() {
+		t.Log("──────── SERVER LOGS ────────")
+		for _, l := range serverLogger.GetLogs() {
+			t.Log(l)
+		}
+		t.Log("──────── WS FRAMES (last 50) ────────")
+		wsLog.PrintLast(50)
+		var html string
+		if err := chromedp.Run(ctx, chromedp.OuterHTML("html", &html, chromedp.ByQuery)); err == nil {
+			t.Logf("──────── RENDERED HTML ────────\n%s", html)
+		} else {
+			t.Logf("(rendered HTML capture failed: %v)", err)
+		}
+	}
+	poll := func(jsExpr string, timeout time.Duration, why string) {
+		t.Helper()
+		deadline := time.Now().Add(timeout)
+		for time.Now().Before(deadline) {
+			var ok bool
+			if err := chromedp.Run(ctx, chromedp.Evaluate(jsExpr, &ok)); err == nil && ok {
+				return
+			}
+			if ctx.Err() != nil {
+				dump()
+				t.Fatalf("chrome ctx cancelled waiting for %s: %v", why, ctx.Err())
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		dump()
+		t.Fatalf("timed out waiting for %s", why)
+	}
+
+	chromeURL := e2etest.GetChromeTestURL(port)
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(chromeURL),
+		chromedp.WaitVisible("#ping", chromedp.ByID),
+	); err != nil {
+		dump()
+		t.Fatalf("navigate: %v", err)
+	}
+
+	// (a) The denied Subscribe surfaced as an lvt:error CustomEvent on the
+	// wrapper with the exact {code,topic} the server emitted.
+	poll(
+		`Array.isArray(window.__lvtErrors) && window.__lvtErrors.length === 1
+		 && window.__lvtErrors[0].code === 'topic_forbidden'
+		 && window.__lvtErrors[0].topic === 'private/admin'`,
+		10*time.Second,
+		"lvt:error CustomEvent {code:topic_forbidden, topic:private/admin}",
+	)
+
+	// (b) The WS is OPEN AND FUNCTIONAL: a real action round-trips and
+	// re-renders. If the server had closed the socket (pre-Phase-4 behavior),
+	// the client's auto-reconnect would re-Mount → re-deny → loop, and #pong
+	// would never become PONG over a live WS.
+	if err := chromedp.Run(ctx, chromedp.Click("#ping", chromedp.ByID)); err != nil {
+		dump()
+		t.Fatalf("click #ping: %v", err)
+	}
+	poll(
+		`document.getElementById('pong') && document.getElementById('pong').textContent === 'PONG'`,
+		10*time.Second,
+		"#pong === 'PONG' (WS action round-trip after the error envelope)",
+	)
+
+	// Sanity: the envelope did NOT also drive a spurious second lvt:error or
+	// leak into the diff path.
+	var errCount int
+	if err := chromedp.Run(ctx, chromedp.Evaluate(`window.__lvtErrors.length`, &errCount)); err != nil {
+		dump()
+		t.Fatalf("read __lvtErrors.length: %v", err)
+	}
+	if errCount != 1 {
+		dump()
+		t.Fatalf("expected exactly one lvt:error, got %d", errCount)
+	}
+}

--- a/e2e/topic_acl_error_envelope_v14_test.go
+++ b/e2e/topic_acl_error_envelope_v14_test.go
@@ -178,6 +178,10 @@ func TestE2E_V14_TopicACLDeniedEmitsLvtErrorAndKeepsWSOpen(t *testing.T) {
 	// tests in this package).
 	serverLogger := e2etest.NewServerLogger()
 	serverLogger.Start()
+	// Teardown ordering matters: `defer serverLogger.Stop()` runs at function
+	// return (LIFO with other defers), while `t.Cleanup` runs *after* all
+	// defers. So slog.SetDefault is restored *after* the logger pipe closes —
+	// no late writes from a shut-down logger into the global slog.
 	defer serverLogger.Stop()
 	prevSlog := slog.Default()
 	slog.SetDefault(slog.New(slog.NewTextHandler(
@@ -287,7 +291,9 @@ func TestE2E_V14_TopicACLDeniedEmitsLvtErrorAndKeepsWSOpen(t *testing.T) {
 		t.Fatalf("read __lvtErrors.length: %v", err)
 	}
 	if errCount != 1 {
+		var errsJSON string
+		_ = chromedp.Run(ctx, chromedp.Evaluate(`JSON.stringify(window.__lvtErrors)`, &errsJSON))
 		dump()
-		t.Fatalf("expected exactly one lvt:error, got %d", errCount)
+		t.Fatalf("expected exactly one lvt:error, got %d; window.__lvtErrors = %s", errCount, errsJSON)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,15 @@ go 1.26.0
 
 require github.com/livetemplate/livetemplate v0.9.1
 
+// Phase 4 (broadcast-action-redesign #415, V14): the lvt V14 chromedp e2e
+// exercises the topic-ACL keep-open behavior, which only exists in the
+// unreleased Phase-0..4 livetemplate. This filesystem replace points at the
+// Phase-4 worktree so the e2e compiles+runs cross-repo. Phase 5's deliverable
+// resolves this into a real version pin (proposal §"Phase 5"); until then the
+// lvt Phase-4 branch is intentionally not independently mergeable / CI-runnable
+// — see docs learnings/phase-4.md cross-repo release order.
+replace github.com/livetemplate/livetemplate => ../../../livetemplate/.worktrees/broadcast-redesign-phase-4
+
 replace github.com/livetemplate/lvt/components => ./components
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,16 @@ require github.com/livetemplate/livetemplate v0.9.1
 // resolves this into a real version pin (proposal §"Phase 5"); until then the
 // lvt Phase-4 branch is intentionally not independently mergeable / CI-runnable
 // — see docs learnings/phase-4.md cross-repo release order.
+//
+// !!! DO NOT RUN `go mod tidy` OR `go build ./...` ON THIS BRANCH !!!
+// The replace path is relative to *this go.mod*; it only resolves on a
+// developer machine where the umbrella workspace has both
+// <umbrella>/lvt/.worktrees/broadcast-redesign-phase-4 (here) AND
+// <umbrella>/livetemplate/.worktrees/broadcast-redesign-phase-4 (target).
+// Other contributors / CI will see `module not found` and `go mod tidy`
+// would corrupt go.sum trying to resolve it. To work on this branch
+// safely use the documented worktree layout, or set the replace to a
+// real version pin first (which is Phase 5's deliverable).
 replace github.com/livetemplate/livetemplate => ../../../livetemplate/.worktrees/broadcast-redesign-phase-4
 
 replace github.com/livetemplate/lvt/components => ./components

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,14 @@ require github.com/livetemplate/livetemplate v0.9.1
 // would corrupt go.sum trying to resolve it. To work on this branch
 // safely use the documented worktree layout, or set the replace to a
 // real version pin first (which is Phase 5's deliverable).
+//
+// Convention note: CONTRIBUTING.md lists Go Workspace as the *Recommended*
+// cross-repo dev path and Manual Replace Directives as the *Alternative*
+// (per-branch). This PR uses the Alternative because (a) it scopes the
+// cross-repo dependency to this branch's git history (a workspace
+// modification doesn't), and (b) it makes the Phase-5 conversion to a real
+// version pin a single-line diff at one greppable anchor. `go.sum` is
+// unchanged from main (filesystem replaces add no sum entries — verified).
 replace github.com/livetemplate/livetemplate => ../../../livetemplate/.worktrees/broadcast-redesign-phase-4
 
 replace github.com/livetemplate/lvt/components => ./components


### PR DESCRIPTION
> [!WARNING]
> **DRAFT — do not merge ahead of livetemplate's Phase-0..4 release.** This PR carries a committed `go.mod` `replace` pointing at `../../../livetemplate/.worktrees/broadcast-redesign-phase-4` (a path that exists only on the author's machine). **CI is guaranteed to fail** with a `module not found` build error until Phase 5's `go.mod` pin bump resolves the `replace` to a real version pin. This is **NOT a CI bug** — it is the [proposal](https://github.com/livetemplate/livetemplate/issues/415)'s documented "lvt e2e gates last (consumes both)" release order. The PR is open as a **tracking artifact**.

Phase 4 of livetemplate's [broadcast-action-redesign (#415)](https://github.com/livetemplate/livetemplate/issues/415). Adds the **Tier-2 user-visible leg of V14** — end-to-end in a real browser against a real livetemplate handler — and the cross-repo `go.mod` `replace` required to build it against the unreleased livetemplate Phase-0..4.

**Companion PRs (release order):** [`livetemplate#427`](https://github.com/livetemplate/livetemplate/pull/427) (server keep-open + Tier-1) **and** [`client#121`](https://github.com/livetemplate/client/pull/121) (TS `lvt:error` branch + jest) are wire-independent and ship first; this PR consumes both.

## V14 (Tier-2 user-visible leg)

`e2e/topic_acl_error_envelope_v14_test.go` (new, `//go:build browser`): verifies that an ACL-denied `ctx.Subscribe` in the WS-connect Mount surfaces in a real browser as an `lvt:error` `CustomEvent` `{ code, topic }` on the wrapper **AND** leaves the WebSocket **open and functional** (advisor sharpening: stays *functional*, not merely un-closed — the test sends a click action over the same socket post-envelope and asserts the rendered value updates).

### Three load-bearing harness decisions, all inline-commented

1. **Full 4-artifact capture** (CLAUDE.md global rule, surfaced on failure):
    - browser console — shared `installConsoleLogger` from `lifecycle_ergonomics_test.go` (same `package e2e_test`, streamed via `t.Logf` live);
    - server logs — `e2etest.NewServerLogger()` teed into the global `slog` default with **save+restore in `t.Cleanup`** (advisor parallel-safety: `slog.SetDefault` is process-global);
    - WS frames — `e2etest.RecordWSFrames` (lvt#317), surfaced via `wsLog.PrintLast`;
    - rendered HTML — `chromedp.OuterHTML("html")` in a `dump()` closure called **before** `t.Fatalf` (chrome ctx is cancelled by `defer cleanup()` before `t.Cleanup` runs; HTML must be captured at failure-time).
    The first failed run during development dumped server logs + WS frames + HTML and surfaced the missing `IsInitialMount` guard (Deviation 3 below) — proof the harness works as intended.
2. **Capture-phase document listener** for the non-bubbling event. The client dispatches `lvt:error` on the wrapper with `bubbles:false`. Installing the listener via `document.addEventListener('lvt:error', …, true)` in a `<head>` script **before** `client.js` loads catches the wrapper dispatch via DOM capture phase (capture traverses window→target regardless of `bubbles`). Race-free without instrumenting the client.
3. **Local Phase-4 client-bundle handler**, **not** `e2etest.ServeClientLibrary`. The canonical helper fetches `@livetemplate/client` from the unpkg CDN and caches on disk for 1h; that cache can shadow `LVT_CLIENT_CDN_URL`, so an unreleased client cannot be reliably served via the canonical path. Reverts to `ServeClientLibrary` in Phase 5/6 after npm publish.

## `IsInitialMount` guard — the e2e exposed a Mount-path dual-fire reality the Tier-1 test does not exercise

Mount runs on **every HTTP request AND WebSocket connect** (livetemplate CLAUDE.md). On the initial HTTP GET (page render), a denied `ctx.Subscribe` surfaces as **HTTP 500** (`mount.go` HTTP-GET path; phase-1.md pre-existing behavior, unchanged by Phase 4). Without the guard, the page would 500 before `client.js` ever loaded and there would be no WS for V14 to exercise. The controller guards with `if ctx.IsInitialMount() { return s, nil }` to scope the denial to the WS-connect Mount — exactly V14's spec scenario.

## Cross-repo `go.mod` `replace` — the Phase-5-resolved dependency artifact

`go.mod` gains:

```
replace github.com/livetemplate/livetemplate => \
    ../../../livetemplate/.worktrees/broadcast-redesign-phase-4
```

…with an inline comment naming Phase 5 as its resolution. **Phase 5's `go.mod pin bump` deliverable is literally "convert this `replace` into a real version pin."** Until then, this PR is correct as a Phase-4-integration tracking commit; **do not merge ahead of livetemplate's Phase-0..4 release**.

## Gate (manual — pre-commit hook not installed in this checkout)

- **lvt non-browser regression GREEN** (Phases 0–4 livetemplate backward-compatible with current lvt code): `GOWORK=off go test -short -count=1 -timeout=120s ./internal/... ./commands/... ./testing/...`
- **V14 Tier-2 browser e2e GREEN** (1.57s end-to-end with full 4-artifact capture): `GOWORK=off go test -tags=browser -v -timeout=5m -run 'TestE2E_V14_TopicACLDeniedEmitsLvtErrorAndKeepsWSOpen' ./e2e/`
- **Added file is lint-clean** (verified with v2 flags `--default=none --enable=errcheck,unused,staticcheck,ineffassign`). The 84+ pre-existing lvt-wide lint issues are pre-existing on lvt `main`, **not** introduced here — the lvt `scripts/pre-commit.sh` has a pre-existing `--disable-all` flag-removed-in-v2 bug at line 36 that silently disabled the lint gate. Flagged in [livetemplate phase-4.md Ledger item 4](https://github.com/livetemplate/livetemplate/blob/broadcast-redesign-phase-4/docs/proposals/broadcast-action-redesign-proposal/learnings/phase-4.md) for a separate Phase-5/6 fix.

## V14 status across the 3 coordinated PRs

| Tier | PR | Status |
|---|---|---|
| Tier 1 — Go integration (server) | [livetemplate#427](https://github.com/livetemplate/livetemplate/pull/427) | ✅ |
| Client logic leg (jest) | [client#121](https://github.com/livetemplate/client/pull/121) | ✅ |
| Tier 2 — chromedp user-visible (this PR) | this | ✅ (local — see `replace` caveat above) |

Server-emitted envelope contract (pinned **byte-for-byte**, asserted by all three tiers):

```json
{"type":"error","code":"topic_forbidden","topic":"<denied topic>"}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
