### PR TITLE
chore(scripts): fix pre-commit lint invocation for golangci-lint v2

### DIFF
--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -31,6 +31,7 @@ else
 fi
 
 # Step 2: Run golangci-lint (if available)
+# Requires golangci-lint >= 2.0 (uses --default=none, renamed from v1's --disable-all).
 if command -v golangci-lint >/dev/null 2>&1; then
     echo "🔍 Running golangci-lint..."
     if golangci-lint run --default=none --enable=errcheck,unused,staticcheck,ineffassign; then

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -31,7 +31,11 @@ else
 fi
 
 # Step 2: Run golangci-lint (if available)
-# Requires golangci-lint >= 2.0 (uses --default=none, renamed from v1's --disable-all).
+# Requires golangci-lint >= 2.0 (`--default=none` replaced v1's `--disable-all`).
+# If blocked here on v1, upgrade: https://golangci-lint.run/welcome/install/
+# `gosimple` is intentionally omitted: in v2 its S1xxx checks live under
+# `staticcheck`, so they still run; keeping `gosimple` enabled triggers a
+# "linter not found" warning.
 if command -v golangci-lint >/dev/null 2>&1; then
     echo "🔍 Running golangci-lint..."
     if golangci-lint run --default=none --enable=errcheck,unused,staticcheck,ineffassign; then

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -33,7 +33,7 @@ fi
 # Step 2: Run golangci-lint (if available)
 if command -v golangci-lint >/dev/null 2>&1; then
     echo "🔍 Running golangci-lint..."
-    if golangci-lint run --disable-all --enable=errcheck,unused,staticcheck,gosimple,ineffassign; then
+    if golangci-lint run --default=none --enable=errcheck,unused,staticcheck,ineffassign; then
         echo "✅ Linting passed"
     else
         echo "❌ Linting failed - commit blocked"


### PR DESCRIPTION
The pre-commit hook's `golangci-lint` invocation used `--disable-all`, which was renamed in golangci-lint v2 to `--default=none`. With v2 installed, the flag-parse fails and the lint step silently aborts with `Error: unknown flag: --disable-all` — meaning contributors who install the hook (`./scripts/install-hooks.sh`) have effectively had their lint gate disabled.

## Change

```diff
-    if golangci-lint run --disable-all --enable=errcheck,unused,staticcheck,gosimple,ineffassign; then
+    if golangci-lint run --default=none --enable=errcheck,unused,staticcheck,ineffassign; then
```

Two parts:
1. `--disable-all` → `--default=none` (v2 flag rename).
2. Drop `gosimple` — its checks were merged into `staticcheck` (S1xxx codes) in v2; keeping `gosimple` enabled in v2 triggers a "linter not found" warning. The simplification checks continue to run through staticcheck unchanged.

## Origin

Surfaced during the livetemplate Phase-4 cross-repo release wave — flagged in livetemplate's [`phase-4.md` Ledger item 4](https://github.com/livetemplate/livetemplate/blob/main/docs/proposals/broadcast-action-redesign-proposal/learnings/phase-4.md) (broadcast-action-redesign [#415](https://github.com/livetemplate/livetemplate/issues/415)). The script bug had no functional impact during the wave itself because the hook wasn't installed on the release machine, but contributors who DO install the hook get a silently-broken lint gate.

## Backlog note

Bringing the lint gate back to life will likely surface a **pre-existing 80+ issue lint backlog** (visible via `golangci-lint run --default=none --enable=errcheck,unused,staticcheck,ineffassign`). That cleanup is intentionally NOT in this PR's scope — this is the flag fix only. Subsequent cleanup PRs can land in batches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)