### PR TITLE
feat(broadcast)!: Phase 5 — pin livetemplate v0.10.0; rename Broadcast→ReloadClients; integrate V14 e2e

### DIFF
--- a/e2e/topic_acl_error_envelope_v14_test.go
+++ b/e2e/topic_acl_error_envelope_v14_test.go
@@ -1,0 +1,273 @@
+//go:build browser
+
+// V14 (Tier-2, user-visible leg) — broadcast-action-redesign #415, Phase 5.
+//
+// An ACL-denied ctx.Subscribe in the WS-connect Mount must, end-to-end in a
+// real browser: (a) surface as an `lvt:error` CustomEvent { code, topic } on
+// the wrapper, and (b) leave the WebSocket OPEN AND FUNCTIONAL (the keep-open
+// finalization shipped in livetemplate Phase 4). The {code,topic} asserted
+// here is byte-for-byte the server-emitted contract
+// (livetemplate topic_runtime.go topicErrorEnvelope) and the client logic-leg
+// jest contract (../client tests/topic-error-envelope.test.ts).
+//
+// Phase 5 cleanup vs the original Phase-4 draft (closed lvt#327, superseded):
+//   - go.mod now pins livetemplate v0.10.0 directly (no `replace`).
+//   - The client bundle is served via the canonical e2etest.ServeClientLibrary
+//     (no `serveLocalPhase4ClientBundle`) now that @livetemplate/client@0.9.2
+//     is on npm with the `lvt:error` branch and there's no cross-repo gating.
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/chromedp/chromedp"
+	"github.com/livetemplate/livetemplate"
+	e2etest "github.com/livetemplate/lvt/testing"
+)
+
+type v14ACLState struct{ Pong string }
+
+type v14ACLController struct{}
+
+// Mount subscribes a developer topic the ACL denies and propagates the error
+// (the canonical `return s, err` real apps use), exercising the WS-connect
+// Mount-failure path that emits the topic_forbidden envelope.
+//
+// IsInitialMount guard: Mount runs on every HTTP request AND WebSocket
+// connect (livetemplate CLAUDE.md "Mount() guard pattern"). On the initial
+// HTTP GET (page render), a denied ctx.Subscribe surfaces as HTTP 500
+// (mount.go HTTP-GET path; phase-1.md "HTTP-GET ACL-denial → HTTP 500" — a
+// pre-existing condition unchanged by Phase 4/5). If we didn't skip the
+// Subscribe on the GET, the page would 500, client.js would never load, and
+// there'd be no WS for V14 to exercise. V14's pinned scenario is exactly the
+// WS-connect Mount denied-Subscribe (envelope + keep-open), so the guard
+// scopes the denial to that path — which is also V14's exact spec wording.
+func (c *v14ACLController) Mount(s v14ACLState, ctx *livetemplate.Context) (v14ACLState, error) {
+	if ctx.IsInitialMount() {
+		return s, nil
+	}
+	if err := ctx.Subscribe("private/admin"); err != nil {
+		return s, err
+	}
+	return s, nil
+}
+
+// Ping is the post-envelope usability probe: a successful action round-trip
+// re-renders #pong, proving the socket stayed FUNCTIONAL — not merely
+// "not closed in the first N ms".
+func (c *v14ACLController) Ping(s v14ACLState, _ *livetemplate.Context) (v14ACLState, error) {
+	s.Pong = "PONG"
+	return s, nil
+}
+
+// The <head> script installs a CAPTURE-phase document listener BEFORE
+// client.js loads and before the WS connects. The client dispatches
+// `lvt:error` on the wrapper as a non-bubbling CustomEvent; a capture-phase
+// document listener still observes it (capture traverses window→target
+// regardless of `bubbles`), which removes the listener-vs-first-frame race
+// without instrumenting the client.
+const v14ACLTemplate = `<!DOCTYPE html>
+<html>
+<head>
+<title>V14 topic ACL error envelope</title>
+<script>
+window.__lvtErrors = [];
+document.addEventListener('lvt:error', function (e) { window.__lvtErrors.push(e.detail); }, true);
+</script>
+</head>
+<body>
+  <div id="pong">{{.Pong}}</div>
+  <button id="ping" lvt-on:click="Ping">Ping</button>
+  <script src="/client.js"></script>
+</body>
+</html>`
+
+func startV14ACLServer(t *testing.T) (port int, shutdown func()) {
+	t.Helper()
+
+	tmpl := livetemplate.Must(livetemplate.New("v14-acl-e2e",
+		livetemplate.WithTopicACL(func(topic, _ string, _ *http.Request) (bool, error) {
+			return topic != "private/admin", nil
+		}),
+	))
+	if _, err := tmpl.Parse(v14ACLTemplate); err != nil {
+		t.Fatalf("parse template: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/", tmpl.Handle(&v14ACLController{}, livetemplate.AsState(&v14ACLState{})))
+	mux.HandleFunc("/client.js", e2etest.ServeClientLibrary)
+
+	p, err := e2etest.GetFreePort()
+	if err != nil {
+		t.Fatalf("free port: %v", err)
+	}
+	server := &http.Server{Addr: fmt.Sprintf(":%d", p), Handler: mux}
+	go func() {
+		// slog (not log.Printf) so a startup error lands in the
+		// serverLogger-captured stream the test surfaces on failure,
+		// not in the default process stderr.
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slog.Error("v14 server ListenAndServe failed", slog.Any("error", err))
+		}
+	}()
+
+	e2etest.WaitForServer(t, fmt.Sprintf("http://localhost:%d", p), 10*time.Second)
+	return p, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		// Log shutdown failures so flaky teardown on slow CI is diagnosable
+		// (currently captured via serverLogger / surfaced on test failure).
+		if err := server.Shutdown(ctx); err != nil {
+			slog.Error("v14 server Shutdown failed", slog.Any("error", err))
+		}
+	}
+}
+
+func TestE2E_V14_TopicACLDeniedEmitsLvtErrorAndKeepsWSOpen(t *testing.T) {
+	// Not parallel: this test mutates the process-global slog.Default. Other
+	// tests in this package that also touch slog.Default (or that observe
+	// livetemplate's internal logging via the same global) would race if
+	// this ran via t.Parallel(). Sibling browser e2es (e.g.
+	// lifecycle_ergonomics_test.go) follow the same non-parallel convention.
+
+	// Artifact 2/4 — server logs. livetemplate logs via the global slog
+	// default (incl. the new "Mount Subscribe denied … connection kept open"
+	// WARN). Tee into a captured buffer; restore the default in Cleanup
+	// (slog.SetDefault is process-global and the default persists across
+	// tests in this package).
+	serverLogger := e2etest.NewServerLogger()
+	serverLogger.Start()
+	// Teardown ordering matters: `defer serverLogger.Stop()` runs at function
+	// return (LIFO with other defers), while `t.Cleanup` runs *after* all
+	// defers. So slog.SetDefault is restored *after* the logger pipe closes —
+	// no late writes from a shut-down logger into the global slog.
+	defer serverLogger.Stop()
+	prevSlog := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(
+		io.MultiWriter(os.Stderr, serverLogger.Writer()),
+		&slog.HandlerOptions{Level: slog.LevelDebug},
+	)))
+	t.Cleanup(func() { slog.SetDefault(prevSlog) })
+
+	port, shutdown := startV14ACLServer(t)
+	defer shutdown()
+
+	chromeCtx, cleanup := e2etest.SetupDockerChrome(t, 60*time.Second)
+	defer cleanup()
+	ctx := chromeCtx.Context
+
+	installConsoleLogger(t, ctx)         // artifact 1/4 — browser console (streamed live)
+	wsLog := e2etest.RecordWSFrames(ctx) // artifact 3/4 — WS frames
+
+	// dump surfaces all four artifacts on failure while the chrome ctx is
+	// still alive (defer cleanup() cancels it before t.Cleanup runs, so HTML
+	// must be captured here, not in Cleanup). Console is already streamed.
+	dump := func() {
+		t.Log("──────── SERVER LOGS ────────")
+		for _, l := range serverLogger.GetLogs() {
+			t.Log(l)
+		}
+		t.Log("──────── WS FRAMES (last 50) ────────")
+		wsLog.PrintLast(50)
+		var html string
+		if err := chromedp.Run(ctx, chromedp.OuterHTML("html", &html, chromedp.ByQuery)); err == nil {
+			t.Logf("──────── RENDERED HTML ────────\n%s", html)
+		} else {
+			t.Logf("(rendered HTML capture failed: %v)", err)
+		}
+	}
+	poll := func(jsExpr string, timeout time.Duration, why string) {
+		t.Helper()
+		deadline := time.Now().Add(timeout)
+		for time.Now().Before(deadline) {
+			var ok bool
+			if err := chromedp.Run(ctx, chromedp.Evaluate(jsExpr, &ok)); err == nil && ok {
+				return
+			}
+			if ctx.Err() != nil {
+				dump()
+				t.Fatalf("chrome ctx cancelled waiting for %s: %v", why, ctx.Err())
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		dump()
+		t.Fatalf("timed out waiting for %s", why)
+	}
+
+	chromeURL := e2etest.GetChromeTestURL(port)
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(chromeURL),
+		chromedp.WaitVisible("#ping", chromedp.ByID),
+	); err != nil {
+		dump()
+		t.Fatalf("navigate: %v", err)
+	}
+
+	// (a) The denied Subscribe surfaced as an lvt:error CustomEvent on the
+	// wrapper with the exact {code,topic} the server emitted.
+	poll(
+		`Array.isArray(window.__lvtErrors) && window.__lvtErrors.length === 1
+		 && window.__lvtErrors[0].code === 'topic_forbidden'
+		 && window.__lvtErrors[0].topic === 'private/admin'`,
+		10*time.Second,
+		"lvt:error CustomEvent {code:topic_forbidden, topic:private/admin}",
+	)
+
+	// (b) Verify the server actually took the Phase-4 keep-open code path —
+	// not just that the client happened to stay connected. The server-side
+	// WARN log is the load-bearing signal that mount.go's *TopicForbiddenError
+	// branch (Option B fall-through) ran instead of the pre-Phase-4 return.
+	// Guards against silent regressions where the WARN is removed without the
+	// corresponding behavior change.
+	//
+	// Coupling: substring of the WARN message in livetemplate's
+	// mount.go (grep anchor: `slog.Warn("Mount Subscribe denied by topic ACL`).
+	// If that prose is reworded, update both here and the
+	// livetemplate-side log call together. A future hardening would be to
+	// switch the server WARN to a structured `slog.String("event", "<key>")`
+	// and assert on the structured key — tracked for Phase 6.
+	if !serverLogger.HasLog("connection kept open") {
+		dump()
+		t.Fatal("expected server to log the Phase-4 keep-open WARN " +
+			"('Mount Subscribe denied by topic ACL; surfaced to client, " +
+			"connection kept open') after ACL denial — the WARN is the proof " +
+			"the server took the keep-open code path, not just that the " +
+			"client happened to stay connected")
+	}
+
+	// (c) The WS is OPEN AND FUNCTIONAL: a real action round-trips and
+	// re-renders. If the server had closed the socket (pre-Phase-4 behavior),
+	// the client's auto-reconnect would re-Mount → re-deny → loop, and #pong
+	// would never become PONG over a live WS.
+	if err := chromedp.Run(ctx, chromedp.Click("#ping", chromedp.ByID)); err != nil {
+		dump()
+		t.Fatalf("click #ping: %v", err)
+	}
+	poll(
+		`document.getElementById('pong') && document.getElementById('pong').textContent === 'PONG'`,
+		10*time.Second,
+		"#pong === 'PONG' (WS action round-trip after the error envelope)",
+	)
+
+	// Sanity: the envelope did NOT also drive a spurious second lvt:error or
+	// leak into the diff path.
+	var errCount int
+	if err := chromedp.Run(ctx, chromedp.Evaluate(`window.__lvtErrors.length`, &errCount)); err != nil {
+		dump()
+		t.Fatalf("read __lvtErrors.length: %v", err)
+	}
+	if errCount != 1 {
+		var errsJSON string
+		_ = chromedp.Run(ctx, chromedp.Evaluate(`JSON.stringify(window.__lvtErrors)`, &errsJSON))
+		dump()
+		t.Fatalf("expected exactly one lvt:error, got %d; window.__lvtErrors = %s", errCount, errsJSON)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/livetemplate/lvt
 
 go 1.26.0
 
-require github.com/livetemplate/livetemplate v0.9.1
+require github.com/livetemplate/livetemplate v0.10.0
 
 replace github.com/livetemplate/lvt/components => ./components
 

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kUL
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/livetemplate/livetemplate v0.9.1 h1:cTPZ9IVOej4CcpGYXjFd4uDVsAnQPiq3YsVITqKLN0s=
-github.com/livetemplate/livetemplate v0.9.1/go.mod h1:GMvZKyPUq8LSGfgD3pftKOHa6v+I+RDYyff2mNjeAYs=
+github.com/livetemplate/livetemplate v0.10.0 h1:4b4H6FPm/b37m+3zcWEuTKJPMKSYFng6RGefIkT86XQ=
+github.com/livetemplate/livetemplate v0.10.0/go.mod h1:GMvZKyPUq8LSGfgD3pftKOHa6v+I+RDYyff2mNjeAYs=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=

--- a/internal/serve/server.go
+++ b/internal/serve/server.go
@@ -183,7 +183,7 @@ func (s *Server) handleFileChange(path string) {
 		s.appMode.HandleFileChange(path)
 	}
 
-	s.wsManager.Broadcast(map[string]interface{}{
+	s.wsManager.ReloadClients(map[string]interface{}{
 		"type": "reload",
 		"path": path,
 	})

--- a/internal/serve/websocket.go
+++ b/internal/serve/websocket.go
@@ -29,7 +29,7 @@ type Client struct {
 
 type WebSocketManager struct {
 	clients    map[*Client]bool
-	broadcast  chan []byte
+	reload     chan []byte
 	register   chan *Client
 	unregister chan *Client
 	mu         sync.RWMutex
@@ -40,7 +40,7 @@ type WebSocketManager struct {
 func NewWebSocketManager() *WebSocketManager {
 	wsm := &WebSocketManager{
 		clients:    make(map[*Client]bool),
-		broadcast:  make(chan []byte, 256),
+		reload:     make(chan []byte, 256),
 		register:   make(chan *Client),
 		unregister: make(chan *Client),
 		stop:       make(chan struct{}),
@@ -80,7 +80,7 @@ func (wsm *WebSocketManager) run() {
 			}
 			wsm.mu.Unlock()
 
-		case message := <-wsm.broadcast:
+		case message := <-wsm.reload:
 			wsm.mu.RLock()
 			clients := make([]*Client, 0, len(wsm.clients))
 			for client := range wsm.clients {
@@ -120,11 +120,7 @@ func (wsm *WebSocketManager) HandleWebSocket(w http.ResponseWriter, r *http.Requ
 	go client.readPump()
 }
 
-// ReloadClients fans out a dev-mode reload payload to every connected client
-// in this WebSocketManager. The old name (Broadcast) was a carryover that
-// conflicted in spirit with the livetemplate v0.10.0 broadcast-action removal
-// — this manager fans out lvt's internal dev-server reload signal over its
-// own WS, not livetemplate's removed broadcast primitive.
+// ReloadClients fans out a dev-mode reload payload to all connected clients.
 func (wsm *WebSocketManager) ReloadClients(data interface{}) {
 	message, err := json.Marshal(data)
 	if err != nil {
@@ -132,7 +128,7 @@ func (wsm *WebSocketManager) ReloadClients(data interface{}) {
 		return
 	}
 
-	wsm.broadcast <- message
+	wsm.reload <- message
 }
 
 func (wsm *WebSocketManager) Close() {

--- a/internal/serve/websocket.go
+++ b/internal/serve/websocket.go
@@ -120,10 +120,15 @@ func (wsm *WebSocketManager) HandleWebSocket(w http.ResponseWriter, r *http.Requ
 	go client.readPump()
 }
 
-func (wsm *WebSocketManager) Broadcast(data interface{}) {
+// ReloadClients fans out a dev-mode reload payload to every connected client
+// in this WebSocketManager. The old name (Broadcast) was a carryover that
+// conflicted in spirit with the livetemplate v0.10.0 broadcast-action removal
+// — this manager fans out lvt's internal dev-server reload signal over its
+// own WS, not livetemplate's removed broadcast primitive.
+func (wsm *WebSocketManager) ReloadClients(data interface{}) {
 	message, err := json.Marshal(data)
 	if err != nil {
-		log.Printf("Failed to marshal broadcast message: %v", err)
+		log.Printf("Failed to marshal reload message: %v", err)
 		return
 	}
 

--- a/internal/serve/websocket_test.go
+++ b/internal/serve/websocket_test.go
@@ -25,7 +25,7 @@ func TestWebSocketManager_CreateAndClose(t *testing.T) {
 	}
 }
 
-func TestWebSocketManager_Broadcast(t *testing.T) {
+func TestWebSocketManager_ReloadClients(t *testing.T) {
 	wsm := NewWebSocketManager()
 	defer wsm.Close()
 
@@ -51,7 +51,7 @@ func TestWebSocketManager_Broadcast(t *testing.T) {
 		"data": "hello",
 	}
 
-	wsm.Broadcast(testData)
+	wsm.ReloadClients(testData)
 
 	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
 	_, message, err := conn.ReadMessage()
@@ -99,7 +99,7 @@ func TestWebSocketManager_MultipleClients(t *testing.T) {
 		t.Errorf("Expected 2 clients, got %d", wsm.ClientCount())
 	}
 
-	wsm.Broadcast(map[string]string{"message": "broadcast"})
+	wsm.ReloadClients(map[string]string{"message": "broadcast"})
 
 	for i, conn := range []*websocket.Conn{conn1, conn2} {
 		_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))


### PR DESCRIPTION
Phase 5 of the broadcast-action-redesign proposal (livetemplate#415) on the lvt side. Three coordinated changes:

## 1. `go.mod` pin v0.9.1 → v0.10.0

livetemplate v0.10.0 ([release](https://github.com/livetemplate/livetemplate/releases/tag/v0.10.0)) ships:
- `ctx.BroadcastAction` removal
- `MaxBroadcastsPerAction` → `MaxPublishesPerAction` rename
- The new `Subscribe`/`Publish` primitive

lvt's internal code does **not** call `ctx.BroadcastAction` itself — it's a CLI/dev-server, not a livetemplate consumer — so the pin bump doesn't require migration on this side, only the V14 e2e re-integration (item 3 below).

## 2. `internal/serve`: `WebSocketManager.Broadcast()` → `ReloadClients()`

Clarity rename. The old name was a Phase-4-era carryover that conflicted in spirit with the livetemplate v0.10.0 "BroadcastAction is gone" line. lvt's `WebSocketManager.Broadcast` is **not** a livetemplate-BroadcastAction consumer — it's lvt's internal dev-server reload-broadcast over its own WebSocket, unrelated to livetemplate's API. `ReloadClients` describes the actual job.

Renamed in 3 files:
- `internal/serve/websocket.go` — func def + godoc
- `internal/serve/server.go` — call site
- `internal/serve/websocket_test.go` — test name + 2 call sites

No behavior change.

## 3. `e2e/topic_acl_error_envelope_v14_test.go` — V14 chromedp Tier-2 e2e

Integrated from the superseded **lvt#327 draft** (closed as superseded 2026-05-20), with two Phase-5 cleanups baked in:

- **`serveLocalPhase4ClientBundle` → `e2etest.ServeClientLibrary`.** The custom local-bundle handler existed because `@livetemplate/client@0.9.2` wasn't on npm yet during the Phase-4 cross-repo dev wave; it's on npm now with the `lvt:error` branch, so the canonical helper works cleanly (no more CDN-cache-shadows-`LVT_CLIENT_CDN_URL` workaround).
- **Committed `replace` removed from go.mod** (the lvt#327 deliverable's resolution). `go.mod` is now a clean v0.10.0 pin.

The three load-bearing harness decisions documented in lvt#327's draft carry forward unchanged:
1. Full **4-artifact capture** (browser console / server logs via `slog.SetDefault` save+restore / WS frames via `RecordWSFrames` / rendered HTML before chrome ctx cancel).
2. **Capture-phase document listener** for the non-bubbling `lvt:error` event (`document.addEventListener('lvt:error', …, true)` in `<head>` before `client.js` loads).
3. **`IsInitialMount` guard** on the controller (Mount runs on both HTTP GET + WS connect; denied Subscribe on GET → HTTP 500 — V14's scenario is the WS-connect-only denial).

## Verification

- ✅ `GOWORK=off go build ./...` clean
- ✅ `GOWORK=off go build -tags=browser ./...` clean
- ✅ `GOWORK=off go test -short -count=1 -timeout=120s ./internal/... ./commands/... ./testing/...` — all packages PASS
- ✅ Full pre-commit gate (`scripts/pre-commit.sh`) green incl. golangci-lint v2 — **0 issues**

V14 browser e2e is gated on `-tags=browser`; not auto-run as part of the short test suite. To exercise locally:
```bash
GOWORK=off go test -tags=browser -v -timeout=5m \
  -run 'TestE2E_V14_TopicACLDeniedEmitsLvtErrorAndKeepsWSOpen' ./e2e/
```

## Refs

- livetemplate#415 — broadcast-action-redesign proposal
- livetemplate#429 — Phase 5 livetemplate-side, MERGED (squash `ad7ff04e`)
- livetemplate v0.10.0 release: https://github.com/livetemplate/livetemplate/releases/tag/v0.10.0
- Closes lvt#327 (superseded — closed 2026-05-20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
