### PR TITLE
Phase 6: lvt#331 fix + GOWORK=off + PollUntil helper + V14 key-assertion (v0.1.8-prep)

### DIFF
--- a/e2e/helpers.go
+++ b/e2e/helpers.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"testing"
 	"time"
 
 	"github.com/chromedp/chromedp"
@@ -64,6 +65,47 @@ func waitForCondition(ctx context.Context, jsCondition string, timeout time.Dura
 			}
 		}
 	}
+}
+
+// PollUntil polls a JS expression against the chromedp ctx until it returns
+// true or the timeout elapses. On failure (timeout or chromedp context
+// cancellation), it invokes the optional onTimeout callback for diagnostic
+// artifact dumping (server logs, WS frames, rendered HTML, etc.) and then
+// calls t.Fatalf with a descriptive message.
+//
+// This is the canonical "dump-aware poll" helper for browser e2e tests. Pass
+// nil for onTimeout if no extra diagnostic dumping is needed beyond the body
+// OuterHTML printed in the Fatalf message.
+//
+// A cancelled chromedp context (browser crash, Docker shutdown, parent test
+// timeout) is fatal immediately — without that early return the loop would
+// silently treat context.Canceled as "condition not yet true" and report a
+// misleading timeout.
+//
+// 100ms poll interval matches lvt/testing's WaitFor convention — chosen there
+// for stability and to avoid CPU thrashing on slow CI runners.
+func PollUntil(t *testing.T, ctx context.Context, jsExpr string, timeout time.Duration, why string, onTimeout func()) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		var ok bool
+		if err := chromedp.Run(ctx, chromedp.Evaluate(jsExpr, &ok)); err == nil && ok {
+			return
+		}
+		if ctx.Err() != nil {
+			if onTimeout != nil {
+				onTimeout()
+			}
+			t.Fatalf("chromedp context cancelled waiting for %s: %v", why, ctx.Err())
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if onTimeout != nil {
+		onTimeout()
+	}
+	var html string
+	_ = chromedp.Run(ctx, chromedp.OuterHTML("body", &html, chromedp.ByQuery))
+	t.Fatalf("timed out waiting for %s. Final DOM body:\n%s", why, html)
 }
 
 // seedTestData seeds test data into SQLite database using parameterized queries

--- a/e2e/helpers.go
+++ b/e2e/helpers.go
@@ -89,14 +89,25 @@ func PollUntil(t *testing.T, ctx context.Context, jsExpr string, timeout time.Du
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		var ok bool
-		if err := chromedp.Run(ctx, chromedp.Evaluate(jsExpr, &ok)); err == nil && ok {
+		err := chromedp.Run(ctx, chromedp.Evaluate(jsExpr, &ok))
+		if err == nil && ok {
 			return
 		}
+		// Context cancellation is fatal immediately — never wait for the
+		// timeout in that case.
 		if ctx.Err() != nil {
 			if onTimeout != nil {
 				onTimeout()
 			}
 			t.Fatalf("chromedp context cancelled waiting for %s: %v", why, ctx.Err())
+		}
+		// Non-cancellation chromedp errors (e.g. detached frame, JS syntax
+		// error, evaluation panic) are surfaced as warnings rather than
+		// swallowed — without this a real error gets misreported as a
+		// generic timeout. We still keep polling: transient errors (DOM not
+		// ready yet, navigation in progress) are expected.
+		if err != nil {
+			t.Logf("PollUntil[%s]: chromedp error (will retry): %v", why, err)
 		}
 		time.Sleep(100 * time.Millisecond)
 	}

--- a/e2e/lifecycle_ergonomics_test.go
+++ b/e2e/lifecycle_ergonomics_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/chromedp/chromedp"
 	"github.com/gorilla/websocket"
 	"github.com/livetemplate/livetemplate"
+	"github.com/livetemplate/lvt/e2e"
 	e2etest "github.com/livetemplate/lvt/testing"
 )
 
@@ -168,32 +169,10 @@ func installConsoleLogger(t *testing.T, ctx context.Context) {
 	})
 }
 
-// requireCondition polls a JS expression until it returns true or the timeout
-// elapses. Used for "DOM should reflect X after WS round-trip" assertions.
-//
-// A cancelled chromedp context (e.g. browser crash, Docker shutdown) is fatal
-// immediately — without that early return the loop would silently treat
-// context.Canceled as "condition not yet true" and report a misleading timeout.
-func requireCondition(t *testing.T, ctx context.Context, jsExpr string, timeout time.Duration, why string) {
-	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		var ok bool
-		err := chromedp.Run(ctx, chromedp.Evaluate(jsExpr, &ok))
-		if err == nil && ok {
-			return
-		}
-		if ctx.Err() != nil {
-			t.Fatalf("chromedp context cancelled waiting for %s: %v", why, ctx.Err())
-		}
-		// 100ms matches lvt/testing's WaitFor convention — chosen there for
-		// stability and to avoid CPU thrashing on slow CI runners.
-		time.Sleep(100 * time.Millisecond)
-	}
-	var html string
-	_ = chromedp.Run(ctx, chromedp.OuterHTML("body", &html, chromedp.ByQuery))
-	t.Fatalf("timed out waiting for %s. Final DOM:\n%s", why, html)
-}
+// (requireCondition was promoted to PollUntil in e2e/helpers.go as the
+// canonical dump-aware poll helper for browser e2e tests. Callers below pass
+// nil for the onTimeout dump callback — the helper still emits body-OuterHTML
+// in the Fatalf message, matching the previous behavior.)
 
 // =============================================================================
 // Test 1 — Issue #340: IsInitialMount fires on the initial HTTP GET.
@@ -259,11 +238,11 @@ func TestE2E_IsReconnect_ReflectsStateRestoration(t *testing.T) {
 	if err := chromedp.Run(ctx, chromedp.Navigate(chromeURL)); err != nil {
 		t.Fatalf("first navigate: %v", err)
 	}
-	requireCondition(t, ctx,
+	e2e.PollUntil(t, ctx,
 		`document.getElementById('rc').innerText.includes('rc=YES')
 		 && document.getElementById('im').innerText.includes('im=NO')`,
 		5*time.Second,
-		"first WS connect to settle (rc=YES, im=NO)")
+		"first WS connect to settle (rc=YES, im=NO)", nil)
 
 	receivedBefore := wsLog.CountByDirection("received")
 
@@ -276,11 +255,11 @@ func TestE2E_IsReconnect_ReflectsStateRestoration(t *testing.T) {
 	if err := chromedp.Run(ctx, chromedp.Reload()); err != nil {
 		t.Fatalf("reload: %v", err)
 	}
-	requireCondition(t, ctx,
+	e2e.PollUntil(t, ctx,
 		`document.getElementById('rc').innerText.includes('rc=YES')
 		 && document.getElementById('im').innerText.includes('im=NO')`,
 		10*time.Second,
-		"reload + WS reconnect to settle (rc=YES, im=NO)")
+		"reload + WS reconnect to settle (rc=YES, im=NO)", nil)
 
 	if got := wsLog.CountByDirection("received") - receivedBefore; got == 0 {
 		wsLog.PrintLast(5)
@@ -316,21 +295,21 @@ func TestE2E_ClearAllFlash_RemovesAllFlashFromDOM(t *testing.T) {
 	if err := chromedp.Run(ctx, chromedp.Click("#set-flashes", chromedp.ByID)); err != nil {
 		t.Fatalf("click set-flashes: %v", err)
 	}
-	requireCondition(t, ctx,
+	e2e.PollUntil(t, ctx,
 		`document.getElementById('flash-success').innerText.includes('Saved!')
 		 && document.getElementById('flash-info').innerText.includes('Heads up')`,
 		5*time.Second,
-		"both flashes to land in DOM after SetFlashes")
+		"both flashes to land in DOM after SetFlashes", nil)
 
 	// 2. Click "Clear all" — invokes ctx.ClearAllFlash. Both flashes vanish.
 	if err := chromedp.Run(ctx, chromedp.Click("#clear-flashes", chromedp.ByID)); err != nil {
 		t.Fatalf("click clear-flashes: %v", err)
 	}
-	requireCondition(t, ctx,
+	e2e.PollUntil(t, ctx,
 		`document.getElementById('flash-success').innerText.trim() === ''
 		 && document.getElementById('flash-info').innerText.trim() === ''`,
 		5*time.Second,
-		"both flashes to clear from DOM after ClearAllFlash")
+		"both flashes to clear from DOM after ClearAllFlash", nil)
 
 	// Sanity: ClearAllFlash must NOT touch non-flash state. OnConnect's
 	// `state.Count++` has run at least once by now, so count must be ≥ 1 —

--- a/e2e/lifecycle_ergonomics_test.go
+++ b/e2e/lifecycle_ergonomics_test.go
@@ -1,11 +1,11 @@
 //go:build browser
 
 // NOTE: this file declares `package e2e_test` (external test package) to match
-// the convention used by `livetemplate_core_test.go`. The local
-// `requireCondition` helper uses the `require*` prefix (Go testing convention
-// for "fatal on failure") to distinguish it from the `chromedp.Action`-returning
-// `waitForCondition` in `helpers.go` and `waitForDOM` in `rendering_test.go`,
-// which return errors instead of calling `t.Fatalf`.
+// the convention used by `livetemplate_core_test.go`. Tests poll for DOM
+// settling via `e2e.PollUntil` (the canonical dump-aware poll helper in
+// `e2e/helpers.go`), which `t.Fatalf`s on timeout — distinct from the
+// `chromedp.Action`-returning `waitForCondition` in `helpers.go` and
+// `waitForDOM` in `rendering_test.go`, which return errors instead.
 package e2e_test
 
 import (
@@ -168,11 +168,6 @@ func installConsoleLogger(t *testing.T, ctx context.Context) {
 		}
 	})
 }
-
-// (requireCondition was promoted to PollUntil in e2e/helpers.go as the
-// canonical dump-aware poll helper for browser e2e tests. Callers below pass
-// nil for the onTimeout dump callback — the helper still emits body-OuterHTML
-// in the Fatalf message, matching the previous behavior.)
 
 // =============================================================================
 // Test 1 — Issue #340: IsInitialMount fires on the initial HTTP GET.

--- a/e2e/topic_acl_error_envelope_v14_test.go
+++ b/e2e/topic_acl_error_envelope_v14_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/chromedp/chromedp"
 	"github.com/livetemplate/livetemplate"
+	"github.com/livetemplate/lvt/e2e"
 	e2etest "github.com/livetemplate/lvt/testing"
 )
 
@@ -184,24 +185,6 @@ func TestE2E_V14_TopicACLDeniedEmitsLvtErrorAndKeepsWSOpen(t *testing.T) {
 			t.Logf("(rendered HTML capture failed: %v)", err)
 		}
 	}
-	poll := func(jsExpr string, timeout time.Duration, why string) {
-		t.Helper()
-		deadline := time.Now().Add(timeout)
-		for time.Now().Before(deadline) {
-			var ok bool
-			if err := chromedp.Run(ctx, chromedp.Evaluate(jsExpr, &ok)); err == nil && ok {
-				return
-			}
-			if ctx.Err() != nil {
-				dump()
-				t.Fatalf("chrome ctx cancelled waiting for %s: %v", why, ctx.Err())
-			}
-			time.Sleep(100 * time.Millisecond)
-		}
-		dump()
-		t.Fatalf("timed out waiting for %s", why)
-	}
-
 	chromeURL := e2etest.GetChromeTestURL(port)
 	if err := chromedp.Run(ctx,
 		chromedp.Navigate(chromeURL),
@@ -213,12 +196,13 @@ func TestE2E_V14_TopicACLDeniedEmitsLvtErrorAndKeepsWSOpen(t *testing.T) {
 
 	// (a) The denied Subscribe surfaced as an lvt:error CustomEvent on the
 	// wrapper with the exact {code,topic} the server emitted.
-	poll(
+	e2e.PollUntil(t, ctx,
 		`Array.isArray(window.__lvtErrors) && window.__lvtErrors.length === 1
 		 && window.__lvtErrors[0].code === 'topic_forbidden'
 		 && window.__lvtErrors[0].topic === 'private/admin'`,
 		10*time.Second,
 		"lvt:error CustomEvent {code:topic_forbidden, topic:private/admin}",
+		dump,
 	)
 
 	// (b) Verify the server actually took the Phase-4 keep-open code path —
@@ -228,19 +212,18 @@ func TestE2E_V14_TopicACLDeniedEmitsLvtErrorAndKeepsWSOpen(t *testing.T) {
 	// Guards against silent regressions where the WARN is removed without the
 	// corresponding behavior change.
 	//
-	// Coupling: substring of the WARN message in livetemplate's
-	// mount.go (grep anchor: `slog.Warn("Mount Subscribe denied by topic ACL`).
-	// If that prose is reworded, update both here and the
-	// livetemplate-side log call together. A future hardening would be to
-	// switch the server WARN to a structured `slog.String("event", "<key>")`
-	// and assert on the structured key — tracked for Phase 6.
-	if !serverLogger.HasLog("connection kept open") {
+	// Coupling: the structured slog attribute `event=topic_acl_denied_keep_open`
+	// emitted by livetemplate's mount.go (grep anchor: `slog.String("event",
+	// "topic_acl_denied_keep_open")` near the `*TopicForbiddenError` branch).
+	// Structured-key assertion is the v0.10.1+ hardening of the previous
+	// substring-of-message coupling — robust against prose rewordings of the
+	// WARN message itself.
+	if !serverLogger.HasLog("event=topic_acl_denied_keep_open") {
 		dump()
-		t.Fatal("expected server to log the Phase-4 keep-open WARN " +
-			"('Mount Subscribe denied by topic ACL; surfaced to client, " +
-			"connection kept open') after ACL denial — the WARN is the proof " +
-			"the server took the keep-open code path, not just that the " +
-			"client happened to stay connected")
+		t.Fatal("expected server to log the keep-open WARN with structured " +
+			"attribute event=topic_acl_denied_keep_open after ACL denial — " +
+			"the attribute is the proof the server took the keep-open code " +
+			"path, not just that the client happened to stay connected")
 	}
 
 	// (c) The WS is OPEN AND FUNCTIONAL: a real action round-trips and
@@ -251,10 +234,11 @@ func TestE2E_V14_TopicACLDeniedEmitsLvtErrorAndKeepsWSOpen(t *testing.T) {
 		dump()
 		t.Fatalf("click #ping: %v", err)
 	}
-	poll(
+	e2e.PollUntil(t, ctx,
 		`document.getElementById('pong') && document.getElementById('pong').textContent === 'PONG'`,
 		10*time.Second,
 		"#pong === 'PONG' (WS action round-trip after the error envelope)",
+		dump,
 	)
 
 	// Sanity: the envelope did NOT also drive a spurious second lvt:error or

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,19 @@ module github.com/livetemplate/lvt
 
 go 1.26.0
 
-require github.com/livetemplate/livetemplate v0.10.0
+// PHASE 6 / v0.10.1-prep: pseudo-version pinned to livetemplate's Phase-6
+// branch (commit 9b4c60c2 on broadcast-redesign-phase-6), which carries the
+// new structured slog attribute `event=topic_acl_denied_keep_open` on
+// mount.go:691 that the V14 e2e test asserts against. This pseudo-version
+// resolves into a real `v0.10.1` pin once the livetemplate Phase-6 PR merges
+// and `release.sh` cuts v0.10.1. Matches the Phase-4/Phase-5 cross-repo
+// dependency-resolution pattern documented in
+// docs/proposals/broadcast-action-redesign-proposal/learnings/phase-4.md
+// (Deviation 3: "committed-`replace`-resolved-by-pin-bump shape"), upgraded
+// here from a worktree-local `replace` (which would not resolve on CI) to a
+// public-branch pseudo-version so the lvt PR's CI runs against the same
+// livetemplate commit the local Phase-6 worktree was tested against.
+require github.com/livetemplate/livetemplate v0.10.1-0.20260521170319-9b4c60c2ac5a
 
 replace github.com/livetemplate/lvt/components => ./components
 

--- a/go.mod
+++ b/go.mod
@@ -2,19 +2,11 @@ module github.com/livetemplate/lvt
 
 go 1.26.0
 
-// PHASE 6 / v0.10.1-prep: pseudo-version pinned to livetemplate's Phase-6
-// branch (commit 9b4c60c2 on broadcast-redesign-phase-6), which carries the
-// new structured slog attribute `event=topic_acl_denied_keep_open` on
-// mount.go:691 that the V14 e2e test asserts against. This pseudo-version
-// resolves into a real `v0.10.1` pin once the livetemplate Phase-6 PR merges
-// and `release.sh` cuts v0.10.1. Matches the Phase-4/Phase-5 cross-repo
-// dependency-resolution pattern documented in
-// docs/proposals/broadcast-action-redesign-proposal/learnings/phase-4.md
-// (Deviation 3: "committed-`replace`-resolved-by-pin-bump shape"), upgraded
-// here from a worktree-local `replace` (which would not resolve on CI) to a
-// public-branch pseudo-version so the lvt PR's CI runs against the same
-// livetemplate commit the local Phase-6 worktree was tested against.
-require github.com/livetemplate/livetemplate v0.10.1-0.20260521170319-9b4c60c2ac5a
+// v0.10.1 introduces the structured slog attribute
+// `event=topic_acl_denied_keep_open` on the Mount Subscribe-denied
+// keep-open WARN; the V14 e2e test in e2e/topic_acl_error_envelope_v14_test.go
+// asserts against that key.
+require github.com/livetemplate/livetemplate v0.10.1
 
 replace github.com/livetemplate/lvt/components => ./components
 

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kUL
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/livetemplate/livetemplate v0.10.1-0.20260521170319-9b4c60c2ac5a h1:5qa9fhaoLOAJDTkNSRBFHKda3obdBSHMjTdCd6exono=
-github.com/livetemplate/livetemplate v0.10.1-0.20260521170319-9b4c60c2ac5a/go.mod h1:GMvZKyPUq8LSGfgD3pftKOHa6v+I+RDYyff2mNjeAYs=
+github.com/livetemplate/livetemplate v0.10.1 h1:pFOYbx1TE1G7Qp4ebIDvYlOBf8ZpKAWdJdU07Of+sE4=
+github.com/livetemplate/livetemplate v0.10.1/go.mod h1:GMvZKyPUq8LSGfgD3pftKOHa6v+I+RDYyff2mNjeAYs=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kUL
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/livetemplate/livetemplate v0.10.0 h1:4b4H6FPm/b37m+3zcWEuTKJPMKSYFng6RGefIkT86XQ=
-github.com/livetemplate/livetemplate v0.10.0/go.mod h1:GMvZKyPUq8LSGfgD3pftKOHa6v+I+RDYyff2mNjeAYs=
+github.com/livetemplate/livetemplate v0.10.1-0.20260521170319-9b4c60c2ac5a h1:5qa9fhaoLOAJDTkNSRBFHKda3obdBSHMjTdCd6exono=
+github.com/livetemplate/livetemplate v0.10.1-0.20260521170319-9b4c60c2ac5a/go.mod h1:GMvZKyPUq8LSGfgD3pftKOHa6v+I+RDYyff2mNjeAYs=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=

--- a/internal/serve/websocket.go
+++ b/internal/serve/websocket.go
@@ -264,8 +264,7 @@ func generateClientID() string {
 	clientCounterMu.Lock()
 	defer clientCounterMu.Unlock()
 	clientCounter++
-	// strconv.FormatUint, not string(rune(...)): the old form converted the
-	// counter to a UTF-8 codepoint (clientCounter=1 → "\x01" control char),
-	// rendering IDs unprintable. Fixes lvt#331.
+	// string(rune(n)) converts to a UTF-8 codepoint (n=1 → "\x01"), making IDs
+	// unprintable. strconv.FormatUint produces the decimal string. Fixes lvt#331.
 	return time.Now().Format("20060102150405") + "-" + strconv.FormatUint(clientCounter, 10)
 }

--- a/internal/serve/websocket.go
+++ b/internal/serve/websocket.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -263,5 +264,8 @@ func generateClientID() string {
 	clientCounterMu.Lock()
 	defer clientCounterMu.Unlock()
 	clientCounter++
-	return time.Now().Format("20060102150405") + "-" + string(rune(clientCounter))
+	// strconv.FormatUint, not string(rune(...)): the old form converted the
+	// counter to a UTF-8 codepoint (clientCounter=1 → "\x01" control char),
+	// rendering IDs unprintable. Fixes lvt#331.
+	return time.Now().Format("20060102150405") + "-" + strconv.FormatUint(clientCounter, 10)
 }

--- a/internal/serve/websocket_test.go
+++ b/internal/serve/websocket_test.go
@@ -7,9 +7,47 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode"
 
 	"github.com/gorilla/websocket"
 )
+
+// TestGenerateClientID guards lvt#331: the prior implementation used
+// `string(rune(clientCounter))` which converted the counter to a UTF-8
+// codepoint (clientCounter=1 → "\x01" SOH), making IDs unprintable. The
+// fix uses strconv.FormatUint to produce the decimal string. This test
+// asserts (a) IDs contain no non-printable bytes, (b) consecutive IDs
+// are unique, and (c) the suffix is the decimal counter (not a rune).
+func TestGenerateClientID(t *testing.T) {
+	// Generate a small sequence; uniqueness + printability is the contract.
+	seen := make(map[string]bool, 8)
+	for i := 0; i < 8; i++ {
+		id := generateClientID()
+		for _, r := range id {
+			if !unicode.IsPrint(r) {
+				t.Fatalf("ID %q contains non-printable rune %U; lvt#331 regression", id, r)
+			}
+		}
+		if seen[id] {
+			t.Fatalf("duplicate ID %q at iteration %d", id, i)
+		}
+		seen[id] = true
+		// Suffix is "-<decimal>"; the last segment should parse as a positive int.
+		if dash := strings.LastIndex(id, "-"); dash >= 0 {
+			suffix := id[dash+1:]
+			if suffix == "" {
+				t.Fatalf("ID %q has empty suffix after '-'", id)
+			}
+			for _, r := range suffix {
+				if r < '0' || r > '9' {
+					t.Fatalf("ID %q suffix %q is not all decimal digits; lvt#331 regression", id, suffix)
+				}
+			}
+		} else {
+			t.Fatalf("ID %q has no '-' separator", id)
+		}
+	}
+}
 
 func TestWebSocketManager_CreateAndClose(t *testing.T) {
 	wsm := NewWebSocketManager()

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -13,12 +13,18 @@ if [ -d "commands/internal" ]; then
     rm -rf commands/internal/
 fi
 
+# All `go` invocations below run with GOWORK=off so the hook is portable
+# across nested-worktree dev setups (e.g. .worktrees/<feature-branch>/),
+# where the workspace's go.work doesn't include the worktree's local module
+# and `go list ./...` otherwise reports "directory prefix . does not contain
+# modules listed in go.work or their selected dependencies". Intentional
+# policy: the hook always tests the module in isolation, ignoring any
+# sibling-module replace directives a contributor may have configured in
+# their workspace go.work. From the main checkout this is a no-op; from a
+# worktree it's the gate that makes the hook self-contained.
+
 # Step 1: Auto-format Go code before validation
 echo "📝 Auto-formatting Go code..."
-# GOWORK=off so nested-worktree runs (e.g. .worktrees/<feature-branch>) don't
-# fail with "directory prefix . does not contain modules listed in go.work
-# or their selected dependencies". When run from the main checkout this is a
-# no-op because the workspace's go.work already includes the lvt module.
 if GOWORK=off go fmt ./...; then
     echo "✅ Code formatting completed"
 

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -15,7 +15,11 @@ fi
 
 # Step 1: Auto-format Go code before validation
 echo "📝 Auto-formatting Go code..."
-if go fmt ./...; then
+# GOWORK=off so nested-worktree runs (e.g. .worktrees/<feature-branch>) don't
+# fail with "directory prefix . does not contain modules listed in go.work
+# or their selected dependencies". When run from the main checkout this is a
+# no-op because the workspace's go.work already includes the lvt module.
+if GOWORK=off go fmt ./...; then
     echo "✅ Code formatting completed"
 
     # Add any formatted files to the commit
@@ -38,7 +42,7 @@ fi
 # "linter not found" warning.
 if command -v golangci-lint >/dev/null 2>&1; then
     echo "🔍 Running golangci-lint..."
-    if golangci-lint run --default=none --enable=errcheck,unused,staticcheck,ineffassign; then
+    if GOWORK=off golangci-lint run --default=none --enable=errcheck,unused,staticcheck,ineffassign; then
         echo "✅ Linting passed"
     else
         echo "❌ Linting failed - commit blocked"
@@ -51,7 +55,7 @@ fi
 
 # Step 3: Run all Go tests with timeout
 echo "🧪 Running Go tests..."
-if go test -v ./... -timeout=120s; then
+if GOWORK=off go test -v ./... -timeout=120s; then
     echo "✅ All tests passed"
 else
     echo "❌ Tests failed - commit blocked"


### PR DESCRIPTION
Phase 6 of the broadcast-redesign wave (livetemplate#415) — lvt side. Coordinated with **livetemplate#430**.

## lvt#331 — generateClientID control-char bug

`internal/serve/websocket.go:266` — `string(rune(clientCounter))` → `strconv.FormatUint(clientCounter, 10)`. The old form converted the integer counter into a single UTF-8 codepoint (\`clientCounter=1\` → \`\"\\x01\"\`, a control character), making client IDs unprintable. Fixes lvt#331.

**Stale memo correction:** the paired "clientCounter mutex race fix" claim in the issue text was verified stale during this work — \`clientCounter\` is accessed only inside \`clientCounterMu\` at lines 262–266, no other reader anywhere. No race to fix.

## scripts/pre-commit.sh — inject GOWORK=off

Nested-worktree runs (\`.worktrees/<feature>/\`) need \`GOWORK=off\` for \`go fmt\` / \`golangci-lint\` / \`go test\` so the workspace's \`go.work\` doesn't shadow the worktree's local module. Otherwise: "directory prefix . does not contain modules listed in go.work or their selected dependencies". No-op when run from the main checkout.

## e2e/helpers.go — promote PollUntil (dump-aware-poll helper)

Two prior inline closures (\`requireCondition\` in \`lifecycle_ergonomics_test.go\`, \`poll\` in \`topic_acl_error_envelope_v14_test.go\`) duplicated the same shape: poll a JS expression, call a diagnostic-dump callback on failure, t.Fatalf with body OuterHTML. Promoted to \`e2e.PollUntil(t, ctx, jsExpr, timeout, why, onTimeout func())\` and both call sites refactored.

## V14 e2e — substring → structured-key assertion

\`topic_acl_error_envelope_v14_test.go\`'s server-side WARN assertion was \`HasLog("connection kept open")\` — a substring of the message text, fragile to prose rewordings. Swapped to \`HasLog("event=topic_acl_denied_keep_open")\` — the structured \`slog.String\` attribute the v0.10.1 livetemplate emits at \`mount.go:691\` (the livetemplate#430 change).

## go.mod pseudo-version

\`go.mod\` pins \`github.com/livetemplate/livetemplate v0.10.1-0.20260521170319-9b4c60c2ac5a\` — pseudo-version of the livetemplate#430 HEAD. This makes the V14 key-assertion run against the slog-key-equipped livetemplate even though v0.10.1 hasn't been cut yet. Phase-4/Phase-5 cross-repo dependency-resolution pattern.

**At release time** (after livetemplate#430 merges + \`release.sh\` cuts v0.10.1): replace the pseudo-version with a real \`v0.10.1\` pin in this PR before tagging \`lvt v0.1.8\`.

## Test status

- Full \`bash scripts/pre-commit.sh\` (now with GOWORK=off) — GREEN.
- V14 e2e (\`TestE2E_V14_TopicACLDeniedEmitsLvtErrorAndKeepsWSOpen\`) — GREEN against the pseudo-version-pinned livetemplate (1.7s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)