### PR TITLE
docs(roadmap): clarify lvt transport broadcast vs livetemplate topic publish

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -348,9 +348,9 @@ Additionally, several features often listed as "missing" are already partially o
 
 ### 4.3 WebSocket Channels / PubSub
 
-**Priority**: Medium — lvt already has a solid WebSocket manager (gorilla/websocket with client management, transport-level broadcast, ping/pong), but it only sends to all clients indiscriminately. Topic-based routing is needed for multi-user features.
+**Priority**: Medium — lvt already has a solid WebSocket manager (gorilla/websocket with client management, transport-level broadcast, ping/pong), but it only sends to all connected clients. Topic-based routing is needed for multi-user features.
 
-> **Terminology note**: lvt's "broadcast" here is the transport-level fan-out (the WebSocket manager's send-to-all-clients primitive). It is *not* the same thing as the livetemplate framework's session-group-scoped `ctx.Publish(topic, ...)` peer fan-out, which routes by topic subscriptions and is opt-in per connection. Section 4.3 below adds the topic-routing layer on top of lvt's transport broadcast, narrowing the conceptual gap.
+> **Terminology note**: lvt's "broadcast" here is the transport-level fan-out (the WebSocket manager's send-to-all-clients primitive). It is *not* the same thing as the livetemplate framework's session-group-scoped `ctx.Publish(topic, ...)` peer fan-out, which routes by topic subscriptions and is opt-in per connection. The acceptance criteria below add the topic-routing layer on top of lvt's transport-level broadcast, closing this gap.
 
 **Current state**: ~75% complete. `WebSocketManager` with client registration, transport broadcast, JSON messaging, and proper cleanup all work. The gap is channel/topic routing.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -350,7 +350,7 @@ Additionally, several features often listed as "missing" are already partially o
 
 **Priority**: Medium — lvt already has a solid WebSocket manager (gorilla/websocket with client management, transport-level broadcast, ping/pong), but it only sends to all connected clients. Topic-based routing is needed for multi-user features.
 
-> **Terminology note**: lvt's "broadcast" here is the transport-level fan-out (the WebSocket manager's send-to-all-clients primitive). It is *not* the same thing as the livetemplate framework's session-group-scoped `ctx.Publish(topic, ...)` peer fan-out, which routes by topic subscriptions and is opt-in per connection. The acceptance criteria below add the topic-routing layer on top of lvt's transport-level broadcast, closing this gap.
+> **Terminology note**: lvt's "broadcast" here is the transport-level fan-out (the WebSocket manager's send-to-all-clients primitive). It is *not* the same thing as the livetemplate framework's `ctx.Publish(topic, ...)`, which routes messages to topic subscribers and is opt-in per connection. The acceptance criteria below add the topic-routing layer on top of lvt's transport-level broadcast, closing the feature gap this section tracks.
 
 **Current state**: ~75% complete. `WebSocketManager` with client registration, transport broadcast, JSON messaging, and proper cleanup all work. The gap is channel/topic routing.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -348,9 +348,11 @@ Additionally, several features often listed as "missing" are already partially o
 
 ### 4.3 WebSocket Channels / PubSub
 
-**Priority**: Medium — lvt already has a solid WebSocket manager (gorilla/websocket with client management, broadcasting, ping/pong), but it only broadcasts to all clients. Topic-based routing is needed for multi-user features.
+**Priority**: Medium — lvt already has a solid WebSocket manager (gorilla/websocket with client management, transport-level broadcast, ping/pong), but it only sends to all clients indiscriminately. Topic-based routing is needed for multi-user features.
 
-**Current state**: ~75% complete. `WebSocketManager` with client registration, broadcast, JSON messaging, and proper cleanup all work. The gap is channel/topic routing.
+> **Terminology note**: lvt's "broadcast" here is the transport-level fan-out (the WebSocket manager's send-to-all-clients primitive). It is *not* the same thing as the livetemplate framework's session-group-scoped `ctx.Publish(topic, ...)` peer fan-out, which routes by topic subscriptions and is opt-in per connection. Section 4.3 below adds the topic-routing layer on top of lvt's transport broadcast, narrowing the conceptual gap.
+
+**Current state**: ~75% complete. `WebSocketManager` with client registration, transport broadcast, JSON messaging, and proper cleanup all work. The gap is channel/topic routing.
 
 **What competitors offer**:
 - Phoenix: Channels with topics, presence tracking, distributed PubSub across nodes
@@ -360,7 +362,7 @@ Additionally, several features often listed as "missing" are already partially o
 **Acceptance Criteria**:
 - [ ] Topic/channel abstraction on top of existing WebSocket manager
 - [ ] Client can subscribe to specific channels (e.g., `room:123`, `user:456`)
-- [ ] Server-side broadcast to channel (only subscribers receive messages)
+- [ ] Server-side publish to channel (only subscribers receive messages)
 - [ ] Presence tracking (who's currently viewing a page/channel)
 - [ ] Private channels with authorization checks
 - [ ] Updated client-side JavaScript library to support channel subscriptions

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -352,7 +352,7 @@ Additionally, several features often listed as "missing" are already partially o
 
 > **Terminology note**: lvt's "broadcast" here is the transport-level fan-out (the WebSocket manager's send-to-all-clients primitive). It is *not* the same thing as the livetemplate framework's `ctx.Publish(topic, ...)`, which routes messages to topic subscribers and is opt-in per connection. The acceptance criteria below add the topic-routing layer on top of lvt's transport-level broadcast, closing the feature gap this section tracks.
 
-**Current state**: ~75% complete. `WebSocketManager` with client registration, transport broadcast, JSON messaging, and proper cleanup all work. The gap is channel/topic routing.
+**Current state**: ~75% complete. `WebSocketManager` with client registration, transport-level broadcast, JSON messaging, and proper cleanup all work. The gap is channel/topic routing.
 
 **What competitors offer**:
 - Phoenix: Channels with topics, presence tracking, distributed PubSub across nodes


### PR DESCRIPTION
## Summary

`docs/ROADMAP.md` Section 4.3 (WebSocket Channels / PubSub) mixed two senses of "broadcast" that became ambiguous after livetemplate v0.10.0 introduced topic-scoped `ctx.Publish`:

- **lvt's `WebSocketManager`** has a literal transport-level send-to-all-clients primitive.
- **livetemplate's pubsub** has session-group-scoped, opt-in topic publishes routed via `Subscribe`.

This PR adds a one-paragraph terminology note distinguishing the two, and renames the section's "Server-side broadcast to channel" acceptance criterion to "Server-side publish to channel" — the gap that section 4.3 closes is precisely the transition from broadcast to publish semantics.

## Changes

- `docs/ROADMAP.md` Section 4.3: terminology note + one acceptance criterion reword.

## Out of scope

No code changes. The `WebSocketManager` API itself keeps its existing "broadcast" naming where it accurately describes the transport-level fan-out behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)