### PR TITLE
test(e2e): chromedp regression for livetemplate#414 + bump to v0.11.1

### DIFF
--- a/e2e/livetemplate_core_test.go
+++ b/e2e/livetemplate_core_test.go
@@ -2563,9 +2563,10 @@ func (c *Issue414Controller) Bump(state Issue414State, _ *livetemplate.Context) 
 // Observability per CLAUDE.md e2e mandate: browser console + server logs +
 // the rendered HTML are all dumped on failure for fast triage.
 func TestIssue414_WrapperInjection_HeadWithBodyDecoy(t *testing.T) {
-	// Server-side log capture for failure diagnostics.
-	var serverLogs bytes.Buffer
-	log.SetOutput(&serverLogs)
+	// Concurrency-safe server-log capture: the server goroutine writes via
+	// log.Printf while dumpDiagnostics reads from the test goroutine.
+	serverLogs := e2etest.NewSafeBuffer()
+	log.SetOutput(serverLogs)
 	defer log.SetOutput(os.Stderr)
 
 	controller := &Issue414Controller{}
@@ -2627,26 +2628,32 @@ func TestIssue414_WrapperInjection_HeadWithBodyDecoy(t *testing.T) {
 	defer cleanup()
 	ctx := chromeCtx.Context
 
-	// Browser console capture.
-	var consoleLines []string
-	chromedp.ListenTarget(ctx, func(ev interface{}) {
-		if api, ok := ev.(*runtime.EventConsoleAPICalled); ok {
-			for _, arg := range api.Args {
-				consoleLines = append(consoleLines, string(arg.Value))
-			}
-		}
-	})
+	// Concurrency-safe browser-console capture via project helper; this also
+	// surfaces EventExceptionThrown that a manual EventConsoleAPICalled
+	// listener would miss.
+	consoleLog := e2etest.NewConsoleLogger()
+	consoleLog.Start(ctx)
 
 	// WebSocket frame capture — the click round-trips over WS; if delegation
 	// breaks, no frame is sent. WS frames are the smoking gun.
 	wsLog := e2etest.RecordWSFrames(ctx)
 
-	// Helper: dump observability on any subsequent failure.
-	dumpDiagnostics := func(label string, renderedHTML string) {
+	// Rendered DOM snapshot for failure diagnostics. Populated initially
+	// from inside the chromedp.Run sequence (pre-click) and refreshed by
+	// snapshotHTML below at failure time to reflect the post-click state.
+	var renderedHTML string
+	snapshotHTML := func() {
+		_ = chromedp.Run(ctx, chromedp.OuterHTML(`html`, &renderedHTML, chromedp.ByQuery))
+	}
+
+	// Helper: dump observability on any subsequent failure. Closes over
+	// all four capture sources for a consistent call-site contract.
+	dumpDiagnostics := func(label string) {
 		t.Logf("=== %s ===", label)
-		t.Logf("--- BROWSER CONSOLE (%d lines) ---", len(consoleLines))
-		for _, line := range consoleLines {
-			t.Logf("console> %s", line)
+		logs := consoleLog.GetLogs()
+		t.Logf("--- BROWSER CONSOLE (%d entries) ---", len(logs))
+		for _, e := range logs {
+			t.Logf("console [%s]> %s", e.Type, e.Message)
 		}
 		t.Logf("--- SERVER LOGS ---")
 		t.Logf("%s", serverLogs.String())
@@ -2663,13 +2670,6 @@ func TestIssue414_WrapperInjection_HeadWithBodyDecoy(t *testing.T) {
 
 	var wrapperAncestorOK bool
 	var counterBefore, counterAfter string
-	var renderedHTML string
-
-	// Helper: snapshot the current DOM into renderedHTML, swallowing the
-	// chromedp error (best-effort capture for failure diagnostics).
-	snapshotHTML := func() {
-		_ = chromedp.Run(ctx, chromedp.OuterHTML(`html`, &renderedHTML, chromedp.ByQuery))
-	}
 
 	err = chromedp.Run(ctx,
 		chromedp.Navigate(url),
@@ -2700,21 +2700,21 @@ func TestIssue414_WrapperInjection_HeadWithBodyDecoy(t *testing.T) {
 	)
 	if err != nil {
 		snapshotHTML()
-		dumpDiagnostics("chromedp Run failed", renderedHTML)
+		dumpDiagnostics("chromedp Run failed")
 		t.Fatalf("chromedp.Run: %v", err)
 	}
 
 	if !wrapperAncestorOK {
-		dumpDiagnostics("wrapper ancestor missing (livetemplate#414 regression)", renderedHTML)
+		dumpDiagnostics("wrapper ancestor missing (livetemplate#414 regression)")
 		t.Fatalf("bump-btn has no [data-lvt-id] ancestor — wrapper was mis-injected (livetemplate#414)")
 	}
 	if counterBefore != "0" {
-		dumpDiagnostics("unexpected initial counter", renderedHTML)
+		dumpDiagnostics("unexpected initial counter")
 		t.Fatalf("initial counter: got %q, want %q", counterBefore, "0")
 	}
 	if counterAfter != "1" {
 		snapshotHTML()
-		dumpDiagnostics("lvt-on:click never propagated (livetemplate#414 regression)", renderedHTML)
+		dumpDiagnostics("lvt-on:click never propagated (livetemplate#414 regression)")
 		t.Fatalf("counter after click: got %q, want %q — click handler was silently dropped", counterAfter, "1")
 	}
 

--- a/e2e/livetemplate_core_test.go
+++ b/e2e/livetemplate_core_test.go
@@ -2565,6 +2565,14 @@ func (c *Issue414Controller) Bump(state Issue414State, _ *livetemplate.Context) 
 func TestIssue414_WrapperInjection_HeadWithBodyDecoy(t *testing.T) {
 	// Concurrency-safe server-log capture: the server goroutine writes via
 	// log.Printf while dumpDiagnostics reads from the test goroutine.
+	//
+	// NOTE: log.SetOutput is process-global, which is broader than ideal —
+	// any goroutine in the same test binary writing via the std log will
+	// also land in serverLogs for the test's duration. livetemplate itself
+	// uses slog (not std log), so the practical leakage is small and
+	// scoped to other tests' own log.Printf calls. The defer restores
+	// os.Stderr immediately when the test returns. Pattern matches
+	// TestExplicitSubmitter_E2E in this file.
 	serverLogs := e2etest.NewSafeBuffer()
 	log.SetOutput(serverLogs)
 	defer log.SetOutput(os.Stderr)
@@ -2575,10 +2583,16 @@ func TestIssue414_WrapperInjection_HeadWithBodyDecoy(t *testing.T) {
 	tmpl := livetemplate.Must(livetemplate.New("issue-414"))
 
 	// The {{.Counter}} directive forces the string-fallback wrapper-injection
-	// path. The CSS comment below contains the literal "<body>" substring
-	// that USED to fool the naive strings.Index scan into mis-positioning
-	// the wrapper. The fix uses html.Tokenizer which correctly skips
-	// over text inside <style> RAWTEXT content.
+	// path. Two independent decoys exercise different parse contexts:
+	//   1. <style>...<body>...</style> — RAWTEXT content where text inside
+	//      a <style> tag would fool a naive strings.Index but is skipped
+	//      by html.Tokenizer.
+	//   2. <meta content="contains a <body literal"> — attribute-value
+	//      content, parsed differently from RAWTEXT but equally invisible
+	//      to a naive scan that doesn't track attribute boundaries.
+	// Both patterns were observed in the wild on the original bug report
+	// and must remain unescaped in the fixture so the regression test
+	// actually exercises the substring match.
 	templateStr := `<!DOCTYPE html>
 <html>
 <head>
@@ -2669,7 +2683,7 @@ func TestIssue414_WrapperInjection_HeadWithBodyDecoy(t *testing.T) {
 	url := e2etest.GetChromeTestURL(port)
 
 	var wrapperAncestorOK bool
-	var counterBefore, counterAfter string
+	var counterAfter string
 
 	err = chromedp.Run(ctx,
 		chromedp.Navigate(url),
@@ -2691,7 +2705,6 @@ func TestIssue414_WrapperInjection_HeadWithBodyDecoy(t *testing.T) {
 			&wrapperAncestorOK,
 		),
 		chromedp.OuterHTML(`html`, &renderedHTML, chromedp.ByQuery),
-		chromedp.Text(`#counter`, &counterBefore, chromedp.ByID),
 		// Assertion 2: the click handler actually fires and triggers a
 		// real server-side state update + WS-driven DOM patch.
 		chromedp.Click(`#bump-btn`, chromedp.ByID),
@@ -2707,10 +2720,6 @@ func TestIssue414_WrapperInjection_HeadWithBodyDecoy(t *testing.T) {
 	if !wrapperAncestorOK {
 		dumpDiagnostics("wrapper ancestor missing (livetemplate#414 regression)")
 		t.Fatalf("bump-btn has no [data-lvt-id] ancestor — wrapper was mis-injected (livetemplate#414)")
-	}
-	if counterBefore != "0" {
-		dumpDiagnostics("unexpected initial counter")
-		t.Fatalf("initial counter: got %q, want %q", counterBefore, "0")
 	}
 	if counterAfter != "1" {
 		snapshotHTML()

--- a/e2e/livetemplate_core_test.go
+++ b/e2e/livetemplate_core_test.go
@@ -2659,7 +2659,12 @@ func TestIssue414_WrapperInjection_HeadWithBodyDecoy(t *testing.T) {
 	// snapshotHTML below at failure time to reflect the post-click state.
 	var renderedHTML string
 	snapshotHTML := func() {
-		_ = chromedp.Run(ctx, chromedp.OuterHTML(`html`, &renderedHTML, chromedp.ByQuery))
+		// Best-effort: if ctx is already cancelled (e.g., test timeout),
+		// renderedHTML will hold its previous value and we log the cause
+		// so failure triage can tell stale-snapshot from fresh-snapshot.
+		if err := chromedp.Run(ctx, chromedp.OuterHTML(`html`, &renderedHTML, chromedp.ByQuery)); err != nil {
+			t.Logf("snapshotHTML: %v (renderedHTML may be stale)", err)
+		}
 	}
 
 	// Helper: dump observability on any subsequent failure. Closes over
@@ -2733,6 +2738,15 @@ func TestIssue414_WrapperInjection_HeadWithBodyDecoy(t *testing.T) {
 		snapshotHTML()
 		dumpDiagnostics("lvt-on:click never propagated (livetemplate#414 regression)")
 		t.Fatalf("click did not propagate to counter update: %v", err)
+	}
+
+	// Fail fast on unexpected JS exceptions or console errors that
+	// might have occurred even though the counter update succeeded —
+	// catches a class of silent regression where the patch lands but
+	// also throws asynchronously.
+	if consoleLog.HasErrors() {
+		dumpDiagnostics("unexpected JS errors during test")
+		t.Errorf("browser logged JS errors during test (see WS+console dumps above)")
 	}
 
 	t.Logf("✅ wrapper ancestor present, lvt-on:click fired through head decoy")

--- a/e2e/livetemplate_core_test.go
+++ b/e2e/livetemplate_core_test.go
@@ -2569,7 +2569,7 @@ func TestIssue414_WrapperInjection_HeadWithBodyDecoy(t *testing.T) {
 	defer log.SetOutput(os.Stderr)
 
 	controller := &Issue414Controller{}
-	state := &Issue414State{Counter: 0}
+	state := &Issue414State{}
 
 	tmpl := livetemplate.Must(livetemplate.New("issue-414"))
 
@@ -2665,10 +2665,25 @@ func TestIssue414_WrapperInjection_HeadWithBodyDecoy(t *testing.T) {
 	var counterBefore, counterAfter string
 	var renderedHTML string
 
+	// Helper: snapshot the current DOM into renderedHTML, swallowing the
+	// chromedp error (best-effort capture for failure diagnostics).
+	snapshotHTML := func() {
+		_ = chromedp.Run(ctx, chromedp.OuterHTML(`html`, &renderedHTML, chromedp.ByQuery))
+	}
+
 	err = chromedp.Run(ctx,
 		chromedp.Navigate(url),
 		chromedp.WaitVisible(`#bump-btn`, chromedp.ByID),
-		e2etest.WaitFor(`typeof window.liveTemplateClient !== 'undefined'`, 5*time.Second),
+		// Wait for the framework's "WS connected" signal — data-lvt-loading
+		// is set server-side and cleared by the client only AFTER the WS
+		// handshake completes. The window.liveTemplateClient defined check
+		// fires too early (after the script tag evaluates but before the
+		// socket is open), so a fast click could be swallowed silently.
+		// Mirrors the pattern documented in TestExplicitSubmitter_E2E.
+		e2etest.WaitFor(`(() => {
+			const w = document.querySelector('[data-lvt-id]');
+			return w && !w.hasAttribute('data-lvt-loading');
+		})()`, 5*time.Second),
 		// Assertion 1: the bump button has a [data-lvt-id] ancestor —
 		// the canonical structural check the client uses for inWrapper.
 		chromedp.Evaluate(
@@ -2684,6 +2699,7 @@ func TestIssue414_WrapperInjection_HeadWithBodyDecoy(t *testing.T) {
 		chromedp.Text(`#counter`, &counterAfter, chromedp.ByID),
 	)
 	if err != nil {
+		snapshotHTML()
 		dumpDiagnostics("chromedp Run failed", renderedHTML)
 		t.Fatalf("chromedp.Run: %v", err)
 	}
@@ -2697,6 +2713,7 @@ func TestIssue414_WrapperInjection_HeadWithBodyDecoy(t *testing.T) {
 		t.Fatalf("initial counter: got %q, want %q", counterBefore, "0")
 	}
 	if counterAfter != "1" {
+		snapshotHTML()
 		dumpDiagnostics("lvt-on:click never propagated (livetemplate#414 regression)", renderedHTML)
 		t.Fatalf("counter after click: got %q, want %q — click handler was silently dropped", counterAfter, "1")
 	}

--- a/e2e/livetemplate_core_test.go
+++ b/e2e/livetemplate_core_test.go
@@ -2572,7 +2572,9 @@ func TestIssue414_WrapperInjection_HeadWithBodyDecoy(t *testing.T) {
 	// uses slog (not std log), so the practical leakage is small and
 	// scoped to other tests' own log.Printf calls. The defer restores
 	// os.Stderr immediately when the test returns. Pattern matches
-	// TestExplicitSubmitter_E2E in this file.
+	// TestExplicitSubmitter_E2E in this file. Do NOT add t.Parallel() to
+	// this test — global log capture is incompatible with parallel
+	// execution and would silently interleave or lose logs.
 	serverLogs := e2etest.NewSafeBuffer()
 	log.SetOutput(serverLogs)
 	defer log.SetOutput(os.Stderr)
@@ -2683,9 +2685,12 @@ func TestIssue414_WrapperInjection_HeadWithBodyDecoy(t *testing.T) {
 	url := e2etest.GetChromeTestURL(port)
 
 	var wrapperAncestorOK bool
-	var counterAfter string
 
-	err = chromedp.Run(ctx,
+	// Segment 1: navigate, wait for WS connect, run the structural
+	// assertion, and snapshot the pre-click DOM. Splitting click+wait
+	// into Segment 2 lets the click-propagation failure carry a more
+	// specific diagnostic label than the generic "chromedp.Run failed".
+	if err := chromedp.Run(ctx,
 		chromedp.Navigate(url),
 		chromedp.WaitVisible(`#bump-btn`, chromedp.ByID),
 		// Wait for the framework's "WS connected" signal — data-lvt-loading
@@ -2705,26 +2710,29 @@ func TestIssue414_WrapperInjection_HeadWithBodyDecoy(t *testing.T) {
 			&wrapperAncestorOK,
 		),
 		chromedp.OuterHTML(`html`, &renderedHTML, chromedp.ByQuery),
-		// Assertion 2: the click handler actually fires and triggers a
-		// real server-side state update + WS-driven DOM patch.
-		chromedp.Click(`#bump-btn`, chromedp.ByID),
-		e2etest.WaitFor(`document.getElementById('counter').textContent === '1'`, 3*time.Second),
-		chromedp.Text(`#counter`, &counterAfter, chromedp.ByID),
-	)
-	if err != nil {
+	); err != nil {
 		snapshotHTML()
-		dumpDiagnostics("chromedp Run failed")
-		t.Fatalf("chromedp.Run: %v", err)
+		dumpDiagnostics("setup / structural-check phase failed")
+		t.Fatalf("chromedp.Run (setup): %v", err)
 	}
 
 	if !wrapperAncestorOK {
 		dumpDiagnostics("wrapper ancestor missing (livetemplate#414 regression)")
 		t.Fatalf("bump-btn has no [data-lvt-id] ancestor — wrapper was mis-injected (livetemplate#414)")
 	}
-	if counterAfter != "1" {
+
+	// Segment 2: click and wait for the counter to reach "1". A failure
+	// here (WaitFor timeout) means the click was dropped or the WS patch
+	// didn't apply — the canonical #414 symptom. The WaitFor itself is
+	// the assertion; no follow-up text comparison is needed because a
+	// successful WaitFor proves the DOM already shows "1".
+	if err := chromedp.Run(ctx,
+		chromedp.Click(`#bump-btn`, chromedp.ByID),
+		e2etest.WaitFor(`document.getElementById('counter').textContent === '1'`, 3*time.Second),
+	); err != nil {
 		snapshotHTML()
 		dumpDiagnostics("lvt-on:click never propagated (livetemplate#414 regression)")
-		t.Fatalf("counter after click: got %q, want %q — click handler was silently dropped", counterAfter, "1")
+		t.Fatalf("click did not propagate to counter update: %v", err)
 	}
 
 	t.Logf("✅ wrapper ancestor present, lvt-on:click fired through head decoy")

--- a/e2e/livetemplate_core_test.go
+++ b/e2e/livetemplate_core_test.go
@@ -2533,3 +2533,173 @@ func TestExplicitSubmitter_E2E(t *testing.T) {
 		t.Errorf("counter after delete: got %q, want %q", counterAfterDelete, "0")
 	}
 }
+
+// Issue414Controller / Issue414State drive the wrapper-injection regression
+// test below.
+type Issue414Controller struct{}
+
+type Issue414State struct {
+	Counter int
+}
+
+// Bump handles "bump" lvt-on:click events.
+func (c *Issue414Controller) Bump(state Issue414State, _ *livetemplate.Context) (Issue414State, error) {
+	state.Counter++
+	return state, nil
+}
+
+// TestIssue414_WrapperInjection_HeadWithBodyDecoy is the end-to-end regression
+// guard for livetemplate#414. It serves a full-HTML template whose <head>
+// contains a CSS comment with a literal "<body>" string — exactly the
+// pattern that previously caused the wrapper injection to mis-position
+// itself and silently break ALL lvt-on:* delegation. The test asserts:
+//
+//  1. The wrapper [data-lvt-id] element exists and is an ANCESTOR of the
+//     interactive button (i.e., wrapper is placed correctly in the DOM).
+//  2. The lvt-on:click handler actually fires end-to-end (counter increments
+//     after click). Before the fix this assertion would fail because the
+//     client-side `inWrapper` ancestor check would reject every click.
+//
+// Observability per CLAUDE.md e2e mandate: browser console + server logs +
+// the rendered HTML are all dumped on failure for fast triage.
+func TestIssue414_WrapperInjection_HeadWithBodyDecoy(t *testing.T) {
+	// Server-side log capture for failure diagnostics.
+	var serverLogs bytes.Buffer
+	log.SetOutput(&serverLogs)
+	defer log.SetOutput(os.Stderr)
+
+	controller := &Issue414Controller{}
+	state := &Issue414State{Counter: 0}
+
+	tmpl := livetemplate.Must(livetemplate.New("issue-414"))
+
+	// The {{.Counter}} directive forces the string-fallback wrapper-injection
+	// path. The CSS comment below contains the literal "<body>" substring
+	// that USED to fool the naive strings.Index scan into mis-positioning
+	// the wrapper. The fix uses html.Tokenizer which correctly skips
+	// over text inside <style> RAWTEXT content.
+	templateStr := `<!DOCTYPE html>
+<html>
+<head>
+	<title>Issue 414 Regression</title>
+	<style>
+		/* layout sits between <body> and the footer */
+		body { font-family: sans-serif; }
+	</style>
+	<meta property="og:description" content="contains a <body literal">
+</head>
+<body>
+	<h1>Wrapper Regression Test</h1>
+	<p>Counter: <strong id="counter">{{.Counter}}</strong></p>
+	<button type="button" id="bump-btn" lvt-on:click="bump">Bump</button>
+	<script src="/client.js"></script>
+</body>
+</html>`
+
+	if _, err := tmpl.Parse(templateStr); err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/", tmpl.Handle(controller, livetemplate.AsState(state)))
+	mux.HandleFunc("/client.js", e2etest.ServeClientLibrary)
+
+	port, err := e2etest.GetFreePort()
+	if err != nil {
+		t.Fatalf("GetFreePort: %v", err)
+	}
+	server := &http.Server{Addr: fmt.Sprintf(":%d", port), Handler: mux}
+	go func() {
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Printf("Server error: %v", err)
+		}
+	}()
+	e2etest.WaitForServer(t, fmt.Sprintf("http://localhost:%d", port), 10*time.Second)
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			t.Logf("Server shutdown warning: %v", err)
+		}
+	}()
+
+	chromeCtx, cleanup := e2etest.SetupDockerChrome(t, 30*time.Second)
+	defer cleanup()
+	ctx := chromeCtx.Context
+
+	// Browser console capture.
+	var consoleLines []string
+	chromedp.ListenTarget(ctx, func(ev interface{}) {
+		if api, ok := ev.(*runtime.EventConsoleAPICalled); ok {
+			for _, arg := range api.Args {
+				consoleLines = append(consoleLines, string(arg.Value))
+			}
+		}
+	})
+
+	// WebSocket frame capture — the click round-trips over WS; if delegation
+	// breaks, no frame is sent. WS frames are the smoking gun.
+	wsLog := e2etest.RecordWSFrames(ctx)
+
+	// Helper: dump observability on any subsequent failure.
+	dumpDiagnostics := func(label string, renderedHTML string) {
+		t.Logf("=== %s ===", label)
+		t.Logf("--- BROWSER CONSOLE (%d lines) ---", len(consoleLines))
+		for _, line := range consoleLines {
+			t.Logf("console> %s", line)
+		}
+		t.Logf("--- SERVER LOGS ---")
+		t.Logf("%s", serverLogs.String())
+		wsFrames := wsLog.GetMessages()
+		t.Logf("--- WEBSOCKET FRAMES (%d) ---", len(wsFrames))
+		for _, m := range wsFrames {
+			t.Logf("ws %s> %s", m.Direction, m.Data)
+		}
+		t.Logf("--- RENDERED HTML ---")
+		t.Logf("%s", renderedHTML)
+	}
+
+	url := e2etest.GetChromeTestURL(port)
+
+	var wrapperAncestorOK bool
+	var counterBefore, counterAfter string
+	var renderedHTML string
+
+	err = chromedp.Run(ctx,
+		chromedp.Navigate(url),
+		chromedp.WaitVisible(`#bump-btn`, chromedp.ByID),
+		e2etest.WaitFor(`typeof window.liveTemplateClient !== 'undefined'`, 5*time.Second),
+		// Assertion 1: the bump button has a [data-lvt-id] ancestor —
+		// the canonical structural check the client uses for inWrapper.
+		chromedp.Evaluate(
+			`document.getElementById('bump-btn').closest('[data-lvt-id]') !== null`,
+			&wrapperAncestorOK,
+		),
+		chromedp.OuterHTML(`html`, &renderedHTML, chromedp.ByQuery),
+		chromedp.Text(`#counter`, &counterBefore, chromedp.ByID),
+		// Assertion 2: the click handler actually fires and triggers a
+		// real server-side state update + WS-driven DOM patch.
+		chromedp.Click(`#bump-btn`, chromedp.ByID),
+		e2etest.WaitFor(`document.getElementById('counter').textContent === '1'`, 3*time.Second),
+		chromedp.Text(`#counter`, &counterAfter, chromedp.ByID),
+	)
+	if err != nil {
+		dumpDiagnostics("chromedp Run failed", renderedHTML)
+		t.Fatalf("chromedp.Run: %v", err)
+	}
+
+	if !wrapperAncestorOK {
+		dumpDiagnostics("wrapper ancestor missing (livetemplate#414 regression)", renderedHTML)
+		t.Fatalf("bump-btn has no [data-lvt-id] ancestor — wrapper was mis-injected (livetemplate#414)")
+	}
+	if counterBefore != "0" {
+		dumpDiagnostics("unexpected initial counter", renderedHTML)
+		t.Fatalf("initial counter: got %q, want %q", counterBefore, "0")
+	}
+	if counterAfter != "1" {
+		dumpDiagnostics("lvt-on:click never propagated (livetemplate#414 regression)", renderedHTML)
+		t.Fatalf("counter after click: got %q, want %q — click handler was silently dropped", counterAfter, "1")
+	}
+
+	t.Logf("✅ wrapper ancestor present, lvt-on:click fired through head decoy")
+}

--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,11 @@ module github.com/livetemplate/lvt
 
 go 1.26.0
 
-// v0.10.1 introduces the structured slog attribute
-// `event=topic_acl_denied_keep_open` on the Mount Subscribe-denied
-// keep-open WARN; the V14 e2e test in e2e/topic_acl_error_envelope_v14_test.go
-// asserts against that key.
-require github.com/livetemplate/livetemplate v0.10.1
+// v0.11.1 ships the html.Tokenizer-based wrapper injection fix
+// (livetemplate#414); the chromedp E2E test in
+// e2e/livetemplate_core_test.go (TestIssue414_WrapperInjection_HeadWithBodyDecoy)
+// requires this version to assert the fix end-to-end.
+require github.com/livetemplate/livetemplate v0.11.1
 
 replace github.com/livetemplate/lvt/components => ./components
 

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kUL
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/livetemplate/livetemplate v0.10.1 h1:pFOYbx1TE1G7Qp4ebIDvYlOBf8ZpKAWdJdU07Of+sE4=
-github.com/livetemplate/livetemplate v0.10.1/go.mod h1:GMvZKyPUq8LSGfgD3pftKOHa6v+I+RDYyff2mNjeAYs=
+github.com/livetemplate/livetemplate v0.11.1 h1:M+RT2ce1iWiRhVG2i64yY9v0sCpYYynztySyndlSEYM=
+github.com/livetemplate/livetemplate v0.11.1/go.mod h1:GMvZKyPUq8LSGfgD3pftKOHa6v+I+RDYyff2mNjeAYs=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=


### PR DESCRIPTION
## Summary

- Adds `TestIssue414_WrapperInjection_HeadWithBodyDecoy` — chromedp E2E that reproduces the **livetemplate#414** wrapper-injection bug end-to-end. A full-HTML template whose `<head>` contains a CSS comment with a literal `<body>` string previously caused the wrapper `[data-lvt-id]` to be mis-injected at the wrong byte offset, silently breaking every `lvt-on:*` event handler while form submits kept working (the misleading partial-failure mode the original issue describes).
- Bumps `require github.com/livetemplate/livetemplate v0.10.1` → **v0.11.1**, which ships the `html.Tokenizer`-based fix in [livetemplate#435](https://github.com/livetemplate/livetemplate/pull/435).

## What the test asserts

1. **Structural**: the interactive button has a `[data-lvt-id]` ancestor — the canonical check the client uses for `inWrapper` delegation. Without the upstream fix, the wrapper landed inside `<head>` and this check returned `null` on every click.
2. **Behavioral**: `lvt-on:click` actually round-trips through WebSocket and the counter increments. This proves the full server → client patch pipeline works when the head contains the literal-`<body>` decoy.

## Observability on failure

Per the CLAUDE.md e2e mandate, on failure the test dumps:

- Browser console (`chromedp.ListenTarget` on `EventConsoleAPICalled`)
- Server logs (`log.SetOutput` redirect to in-test buffer)
- WebSocket frames sent + received (`e2etest.RecordWSFrames` from `lvt/testing/websocket.go`)
- Rendered HTML (`chromedp.OuterHTML('html')`)

## Two-way verification done during development

Locally verified the test PASSES against the fixed v0.11.1 AND FAILS against the unfixed v0.10.1. On v0.10.1 the failure mode is even stronger than `lvt-on:*` silently failing: the wrapper got mis-positioned so badly that the `<script src="/client.js">` tag was mangled and the page failed to bootstrap at all (`script: no-script-tag, client: missing, wrapper: missing`). So this test is a strong regression guard, not a precarious one.

## Test plan

- [x] `go test -tags browser -count=1 -run TestIssue414_WrapperInjection_HeadWithBodyDecoy ./e2e/...` PASS locally against v0.11.1
- [x] Same test FAILS against v0.10.1 (verified by temporarily pinning go.mod)
- [x] `go build ./...` clean against v0.11.1
- [x] Lvt's `scripts/pre-commit.sh` passes (gofmt + tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)