### PR TITLE
fix(release): survive an aborted release instead of leaving a half-bumped tree

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -82,7 +82,6 @@ bump_version() {
     echo "${major}.${minor}.${patch}"
 }
 
-# Update version files
 # Restore VERSION / CHANGELOG.md if the release aborts after they are written
 # but before the release commit lands. Without this, an abort (a flaky test, a
 # failed tag) leaves a dirty tree — and main() refuses to run on a dirty tree,
@@ -91,18 +90,36 @@ release_files_written=false
 release_committed=false
 
 restore_release_files() {
-    if [ "$release_files_written" = true ] && [ "$release_committed" = false ]; then
-        log_warn "Release aborted before committing — restoring VERSION and CHANGELOG.md"
-        # Restore from HEAD, not from the index: commit_and_tag stages both files
-        # before committing, so if the commit itself fails they are already
-        # staged and a plain `git checkout --` would restore them from the index
-        # — copying the modified versions back over themselves.
-        git checkout HEAD -- VERSION CHANGELOG.md 2>/dev/null || \
-            log_warn "Could not restore VERSION / CHANGELOG.md; revert them by hand before retrying"
-    fi
+    [ "$release_files_written" = true ] || return 0
+    [ "$release_committed" = false ] || return 0
+
+    log_warn "Release aborted before committing — restoring VERSION and CHANGELOG.md"
+
+    # Restore from HEAD, not from the index: commit_and_tag stages both files
+    # before committing, so if the commit itself fails they are already staged
+    # and a plain `git checkout --` would restore them from the index — copying
+    # the modified versions back over themselves.
+    #
+    # One path per invocation. `git checkout HEAD -- a b` resolves the pathspec
+    # first and bails before touching the worktree if any entry is missing from
+    # HEAD, so a single call would restore *neither* file when one is untracked.
+    # That is reachable here: commit_and_tag guards CHANGELOG.md with `[ -f ]`,
+    # so this script already allows for a repo without one. git's stderr is left
+    # visible; a generic "couldn't restore" would send the next person down the
+    # wrong trail.
+    local f
+    for f in VERSION CHANGELOG.md; do
+        if git cat-file -e "HEAD:$f" 2>/dev/null; then
+            git checkout HEAD -- "$f" || \
+                log_warn "Could not restore $f; revert it by hand before retrying"
+        else
+            log_warn "$f is not in HEAD — this run created it; delete it by hand before retrying"
+        fi
+    done
 }
 trap restore_release_files EXIT
 
+# Update version files
 update_versions() {
     local new_version=$1
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -112,8 +112,16 @@ restore_release_files() {
         if git cat-file -e "HEAD:$f" 2>/dev/null; then
             git checkout HEAD -- "$f" || \
                 log_warn "Could not restore $f; revert it by hand before retrying"
-        else
-            log_warn "$f is not in HEAD — this run created it; delete it by hand before retrying"
+        elif [ -f "$f" ]; then
+            # Absent from HEAD but on disk means this run created it: main()
+            # refuses to start on a dirty tree and `git status --porcelain`
+            # lists untracked files, so it cannot have pre-existed. Removing it
+            # restores the exact pre-run state. Both steps are needed —
+            # commit_and_tag may already have staged it, and a bare `rm` would
+            # leave an "A " entry that still counts as dirty.
+            git rm -f --quiet --ignore-unmatch -- "$f" 2>/dev/null || true
+            rm -f "$f"
+            log_warn "Removed $f, which this run created"
         fi
     done
 }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -83,10 +83,31 @@ bump_version() {
 }
 
 # Update version files
+# Restore VERSION / CHANGELOG.md if the release aborts after they are written
+# but before the release commit lands. Without this, an abort (a flaky test, a
+# failed tag) leaves a dirty tree — and main() refuses to run on a dirty tree,
+# so the retry is blocked until someone works out what to revert.
+release_files_written=false
+release_committed=false
+
+restore_release_files() {
+    if [ "$release_files_written" = true ] && [ "$release_committed" = false ]; then
+        log_warn "Release aborted before committing — restoring VERSION and CHANGELOG.md"
+        # Restore from HEAD, not from the index: commit_and_tag stages both files
+        # before committing, so if the commit itself fails they are already
+        # staged and a plain `git checkout --` would restore them from the index
+        # — copying the modified versions back over themselves.
+        git checkout HEAD -- VERSION CHANGELOG.md 2>/dev/null || \
+            log_warn "Could not restore VERSION / CHANGELOG.md; revert them by hand before retrying"
+    fi
+}
+trap restore_release_files EXIT
+
 update_versions() {
     local new_version=$1
 
     log_step "Updating VERSION file to $new_version"
+    release_files_written=true
     echo "$new_version" > VERSION
 
     log_info "Version files updated to $new_version"
@@ -152,6 +173,10 @@ commit_and_tag() {
 Release LVT CLI v$new_version
 
 🤖 Generated with automated release script"
+
+    # VERSION / CHANGELOG.md now live in a commit; restoring them on a later
+    # failure would discard the release commit itself, so stand the guard down.
+    release_committed=true
 
     log_step "Creating git tag v$new_version"
     git tag -a "v$new_version" -m "Release v$new_version"
@@ -420,10 +445,15 @@ main() {
     log_info "Starting release process..."
     echo ""
 
-    # Execute release steps
+    # Execute release steps. Tests run FIRST, before anything is written: the
+    # only Go code reading the VERSION file is getCurrentVersion(), which no
+    # test exercises (and which resolves to "unknown" under `go test` anyway,
+    # since it reads a relative path from the package directory). So the bump
+    # cannot change the result, and a failure — a flaky test especially — leaves
+    # the tree untouched instead of half-bumped.
+    build_and_test
     update_versions "$new_version"
     generate_changelog "$new_version"
-    build_and_test
     commit_and_tag "$new_version"
     publish_github "$new_version" "$branch"
 


### PR DESCRIPTION
Same ordering bug as livetemplate#499 — found while releasing livetemplate v0.19.1, then confirmed present here.

## The problem

The step order was `update_versions` → `generate_changelog` → `build_and_test`, so a test failure aborted with `VERSION` and `CHANGELOG.md` already rewritten:

```
 M CHANGELOG.md
 M VERSION
```

`main()` refuses to start on a dirty tree, so the retry is blocked until someone works out what to revert — a confusing trap at exactly the wrong moment, and the failure that triggers it is most likely a flake.

## The fix

**`build_and_test` runs first.** Worth a note for this repo specifically, because unlike core, lvt *does* read the `VERSION` file from Go — `getCurrentVersion()` in `commands/install_agent.go`. It's safe regardless: no test exercises it, and it resolves to `"unknown"` under `go test` anyway since it reads a relative path from the package directory.

**A trap covers the remaining window** between writing the files and committing. It restores from `HEAD`, not the index:

> `commit_and_tag` stages `VERSION` (and `CHANGELOG.md`) before committing, so on a failed commit they are already staged. A plain `git checkout --` restores from the index — copying the modified versions back over themselves.

That was a real bug in the first draft of the core fix, caught by the abort test rather than by reading the diff.

## Verification

In a throwaway clone with a forced post-bump failure:

- `VERSION` restored to `0.2.0`, **0 dirty files**, retry unblocked
- reorder visible in the log — `Running Go tests…` precedes `Updating VERSION file`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ui2cwpeGkrUfRt8rh2FgGG