### PR TITLE
docs: point the cross-repo reference links at the docs site

### DIFF
--- a/docs/guides/lvt-cli-guide.md
+++ b/docs/guides/lvt-cli-guide.md
@@ -820,6 +820,6 @@ go run cmd/mysocial/main.go
 5. **Deploy** - Build and deploy your app
 
 For more information:
-- [API Reference](../references/api-reference.md)
-- [Template Support Matrix](../references/template-support-matrix.md)
+- [API Reference](https://livetemplate.fly.dev/reference/api)
+- [Template Support Matrix](https://livetemplate.fly.dev/reference/template-support-matrix)
 - [LiveTemplate Documentation](https://github.com/livetemplate/livetemplate)


### PR DESCRIPTION
The CLI guide's "For more information" list links two references that cannot resolve from this repo:

```
- [API Reference](../references/api-reference.md)
- [Template Support Matrix](../references/template-support-matrix.md)
```

From `docs/guides/`, `../` is `docs/` — and `lvt` has no `docs/references/` directory at all. Both documents describe the core library and live in `livetemplate/livetemplate`, so a relative path was never going to reach them from here.

Pointed at their rendered home on the docs site instead. That is stable across repo layout changes, and it is where someone reading a CLI guide actually wants to land — the rendered reference rather than raw markdown.

## How it surfaced

The docs site mirrors this guide to `/cli/`. Its sync tool now resolves upstream-relative links when mirroring (livetemplate/docs#130), because they were previously shipped verbatim and 404'd for every reader of the site. Resolving these two faithfully produced `lvt/blob/v0.2.0/docs/references/api-reference.md`, a 404 — which is how the underlying mistake became visible. The links were equally broken before, just silently.

No behaviour change; documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzC2djPjPHkNJgPzFpMX7v