### PR TITLE
docs: drop the hype words from the mirrored CLI pages

### DIFF
--- a/components/README.md
+++ b/components/README.md
@@ -2,7 +2,7 @@
 
 ![Components Independence](https://github.com/livetemplate/lvt/actions/workflows/components-independence.yml/badge.svg)
 
-A comprehensive collection of reusable UI components for the [LiveTemplate](https://github.com/livetemplate/livetemplate) framework.
+A set of reusable UI components for the [LiveTemplate](https://github.com/livetemplate/livetemplate) framework.
 
 ## Features
 
@@ -82,7 +82,7 @@ CountrySelect: dropdown.NewSearchable("country", countries,
 |-----------|---------|-----------|-------------|
 | Toast | `toast` | default, container | Toast notifications |
 | Tooltip | `tooltip` | default | Tooltips |
-| Popover | `popover` | default | Rich content popovers |
+| Popover | `popover` | default | Content popovers |
 | Progress | `progress` | default, circular, spinner | Progress indicators |
 | Skeleton | `skeleton` | default, avatar, card | Loading placeholders |
 

--- a/docs/guides/auth-customization.md
+++ b/docs/guides/auth-customization.md
@@ -19,7 +19,7 @@ After running `lvt gen auth`, edit `internal/app/auth/auth.tmpl` to use your pre
 
 ### Option 2: Use a Kit
 
-The lvt kit system allows you to customize templates project-wide.
+The lvt kit system lets you customize templates across the whole project.
 
 1. **Copy the auth template to your project kit:**
    ```bash

--- a/docs/guides/lvt-cli-guide.md
+++ b/docs/guides/lvt-cli-guide.md
@@ -160,7 +160,7 @@ lvt gen products name price quantity enabled created_at
 - Form validation
 - Statistics/counts
 - CSS styling (from kit)
-- Comprehensive tests
+- Generated tests covering each flow
 
 **Type Mappings:**
 
@@ -291,7 +291,7 @@ Default names (can be customized):
 - **Auto-updates `go.mod` dependencies**
 - **EmailSender interface** (console logger + SMTP/Mailgun examples)
 - **Case-insensitive email matching**
-- **Production-ready security** (HTTP-only, secure, SameSite cookies)
+- **Secure session cookies** (HTTP-only, Secure, SameSite)
 
 **Next Steps:**
 
@@ -345,7 +345,7 @@ The generated auth templates use Tailwind CSS by default. To use a different CSS
 
 **E2E Testing:**
 
-The auth command generates comprehensive E2E tests using chromedp that test all auth flows:
+The auth command generates E2E tests using chromedp that cover every auth flow:
 - Registration flow (with email confirmation if enabled)
 - Login flow (password and magic-link)
 - Password reset flow (if enabled)
@@ -541,7 +541,7 @@ lvt gen articles title content published_at author email price
 
 ## Testing
 
-Each generated resource includes comprehensive tests.
+Each generated resource comes with tests.
 
 ### WebSocket Tests (`*_ws_test.go`)
 

--- a/testing/README.md
+++ b/testing/README.md
@@ -1,6 +1,6 @@
 # LiveTemplate Testing Framework
 
-A comprehensive e2e testing framework for LiveTemplate applications that reduces boilerplate by 85-90%.
+An e2e testing framework for LiveTemplate applications. It cuts test boilerplate by 85-90%.
 
 ## Installation
 
@@ -46,7 +46,7 @@ func TestMyApp(t *testing.T) {
 - **WebSocket Ready**: Waits for LiveTemplate WebSocket connection
 - **Cleanup**: Automatic teardown of all resources
 
-### Comprehensive Loggers
+### Loggers
 ```go
 // Browser console logs
 test.Console.GetLogs()


### PR DESCRIPTION
These four files mirror to `/cli` on the docs site, which now has a written voice — [`VOICE.md`](https://github.com/livetemplate/docs/blob/main/VOICE.md), added in livetemplate/docs#137. The docs-native pages were audited against it and came out clean. These did not.

## What changed

`comprehensive` appeared five times and told a reader nothing. A test suite either covers the flows or it doesn't, so the text now says which:

- "generates comprehensive E2E tests using chromedp that test all auth flows" → "generates E2E tests using chromedp that cover every auth flow"
- "Each generated resource includes comprehensive tests." → "Each generated resource comes with tests."
- "A comprehensive e2e testing framework … that reduces boilerplate by 85-90%" → "An e2e testing framework … It cuts test boilerplate by 85-90%."

`**Production-ready security** (HTTP-only, secure, SameSite cookies)` became `**Secure session cookies** (HTTP-only, Secure, SameSite)` — the parenthetical was already the real claim.

`Rich content popovers` → `Content popovers`. And one nominalization: "allows you to customize templates project-wide" → "lets you customize templates across the whole project".

## Left alone

**Headings.** Title Case is these documents' own convention, consistently applied across ~90 headings. Changing them is a rename, not a copy edit, and it would bury the actual fix in churn. Worth doing separately if you want it.

## Verification

0 `.go` files touched — the diff is 4 markdown files. The repo's pre-commit hook (gofmt, golangci-lint, `go test`) ran and passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166MK1arBYbVZq6wfm8EsQZ